### PR TITLE
Issue22

### DIFF
--- a/include/predict/predict.h.in
+++ b/include/predict/predict.h.in
@@ -117,6 +117,11 @@ typedef struct {
 	double bstar_drag_term;
 	///Number of revolutions around Earth at epoch (line 2, field 9)
 	int revolutions_at_epoch;
+
+	///Which perturbation model to use
+	enum predict_ephemeris ephemeris;
+	///Ephemeris data structure pointer
+	void *ephemeris_data;
 } predict_orbital_elements_t;
 
 /**
@@ -126,7 +131,13 @@ typedef struct {
  * \return Processed TLE parameters
  * \copyright GPLv2+
  **/
-predict_orbital_elements_t predict_parse_tle(char *tle[2]);
+predict_orbital_elements_t* predict_parse_tle(char *tle[2]);
+
+/**
+ * Free memory allocated in orbital elements structure.
+ * \param orbital_elements Orbit to free
+ **/
+void predict_destroy_orbital_elements(predict_orbital_elements_t *orbital_elements);
 
 
 /**
@@ -167,11 +178,6 @@ typedef struct {
 	double right_ascension;
 	///Current argument of perigee (from omgadf within sgp4/sdp4)
 	double argument_of_perigee;
-
-	///Which perturbation model to use
-	enum predict_ephemeris ephemeris;
-	///Ephemeris data structure pointer
-	void *ephemeris_data;
 } predict_orbit_t;
 
 
@@ -180,7 +186,7 @@ typedef struct {
  * \return Allocated orbit structure
  * \copyright GPLv2+
  **/
-predict_orbit_t *predict_create_orbit(predict_orbital_elements_t orbital_elements);
+predict_orbit_t *predict_create_orbit();
 
 /**
  * Free memory allocated in orbit structure. 

--- a/include/predict/predict.h.in
+++ b/include/predict/predict.h.in
@@ -140,7 +140,7 @@ void predict_destroy_orbital_elements(predict_orbital_elements_t *orbital_elemen
 /**
  * Predicted orbital values for satellite at a given time.
  **/
-typedef struct {
+struct predict_orbit {
 	///Timestamp for last call to orbit_predict
 	predict_julian_date_t time;
 
@@ -175,7 +175,7 @@ typedef struct {
 	double right_ascension;
 	///Current argument of perigee (from omgadf within sgp4/sdp4)
 	double argument_of_perigee;
-} predict_orbit_t;
+};
 
 /**
  * Main prediction function. Predict satellite orbit at given time. 
@@ -185,7 +185,7 @@ typedef struct {
  * \return 0 if everything went fine
  * \copyright GPLv2+
  **/
-int predict_orbit(const predict_orbital_elements_t *orbital_elements, predict_orbit_t *x, predict_julian_date_t time);
+int predict_orbit(const predict_orbital_elements_t *orbital_elements, struct predict_orbit *x, predict_julian_date_t time);
 
 /**
  * Find whether orbit is geostationary. 
@@ -223,22 +223,6 @@ double predict_perigee(const predict_orbital_elements_t *x);
  * \copyright GPLv2+
  **/
 bool predict_aos_happens(const predict_orbital_elements_t *x, double latitude);
-
-/** 
- * Find whether a satellite is currently eclipsed.
- *
- * \param x Current state of orbit
- * \return true if orbit is eclipsed, otherwise false
- **/
-bool predict_is_eclipsed(const predict_orbit_t *x);
-
-/** 
- * Return the eclipse depth
- *
- * \param x Current state of orbit
- * \return Eclipse depth (rad)
- **/
-double predict_eclipse_depth(const predict_orbit_t *x);
 
 /**
  * Observation point/ground station (QTH).
@@ -308,7 +292,7 @@ void predict_destroy_observer(predict_observer_t *obs);
  * \param obs Return of object for position of the satellite relative to the observer.
  * \copyright GPLv2+
  **/
-void predict_observe_orbit(const predict_observer_t *observer, const predict_orbit_t *orbit, struct predict_observation *obs);
+void predict_observe_orbit(const predict_observer_t *observer, const struct predict_orbit *orbit, struct predict_observation *obs);
 
 /**
  * Estimate relative position of the moon.
@@ -361,7 +345,7 @@ predict_julian_date_t predict_next_los(const predict_observer_t *observer, const
  * \return The frequency difference from the original frequency
  * \copyright GPLv2+
  **/
-double predict_doppler_shift(const predict_observer_t *observer, const predict_orbit_t *orbit, double downlink_frequency);
+double predict_doppler_shift(const predict_observer_t *observer, const struct predict_orbit *orbit, double downlink_frequency);
 
 /**
  * Calculate squint angle for satellite, i.e. angle between the satellite antenna and the QTH antenna.
@@ -375,7 +359,7 @@ double predict_doppler_shift(const predict_observer_t *observer, const predict_o
  * \return Squint angle in radians. Will output nan if the satellite is not an SDP4 satellite
  * \copyright GPLv2+
  **/
-double predict_squint_angle(const predict_observer_t *observer, const predict_orbit_t *orbit, double alon, double alat);
+double predict_squint_angle(const predict_observer_t *observer, const struct predict_orbit *orbit, double alon, double alat);
 
 /*!
  * \brief Calculate refraction angle.

--- a/include/predict/predict.h.in
+++ b/include/predict/predict.h.in
@@ -86,8 +86,6 @@ enum predict_ephemeris {
 typedef struct {
 	///Name of satellite
 	char name[128];
-	///Which perturbation model to use
-	enum predict_ephemeris ephemeris;
 
 	///Satellite number (line 1, field 2)
 	int satellite_number;
@@ -159,6 +157,8 @@ typedef struct {
 	///The current number of revolutions around Earth
 	long revolutions;
 
+	///Which perturbation model to use
+	enum predict_ephemeris ephemeris;
 	///Ephemeris data structure pointer
 	void *ephemeris_data;
 } predict_orbit_t;
@@ -169,7 +169,7 @@ typedef struct {
  * \return Allocated orbit structure
  * \copyright GPLv2+
  **/
-predict_orbit_t *predict_create_orbit();
+predict_orbit_t *predict_create_orbit(predict_orbital_elements_t orbital_elements);
 
 /**
  * Free memory allocated in orbit structure. 

--- a/include/predict/predict.h.in
+++ b/include/predict/predict.h.in
@@ -84,9 +84,6 @@ enum predict_ephemeris {
  * Container for processed TLE data from TLE strings.
  **/
 typedef struct {
-	///Name of satellite
-	char name[128];
-
 	///Satellite number (line 1, field 2)
 	int satellite_number;
 	///Element number (line 1, field 13)
@@ -179,20 +176,6 @@ typedef struct {
 	///Current argument of perigee (from omgadf within sgp4/sdp4)
 	double argument_of_perigee;
 } predict_orbit_t;
-
-
-/**
- * Create orbit structure. Allocate memory and prepare internal data.
- * \return Allocated orbit structure
- * \copyright GPLv2+
- **/
-predict_orbit_t *predict_create_orbit();
-
-/**
- * Free memory allocated in orbit structure. 
- * \param orbit Orbit to free
- **/
-void predict_destroy_orbit(predict_orbit_t *orbit);
 
 /**
  * Main prediction function. Predict satellite orbit at given time. 

--- a/include/predict/predict.h.in
+++ b/include/predict/predict.h.in
@@ -350,8 +350,6 @@ double predict_doppler_shift(const predict_observer_t *observer, const struct pr
 /**
  * Calculate squint angle for satellite, i.e. angle between the satellite antenna and the QTH antenna.
  *
- * \note The squint angle is defined only for SDP4 satellites for now.
- *
  * \param observer Point of observation
  * \param orbit Current state of satellite orbit
  * \param alon Attitude longitude in radians (describes orientation of the satellite at apogee)

--- a/include/predict/predict.h.in
+++ b/include/predict/predict.h.in
@@ -161,6 +161,13 @@ typedef struct {
 	///The current number of revolutions around Earth
 	long revolutions;
 
+	///Current inclination (from xinck within sgp4/sdp4)
+	double inclination;
+	///Current right ascension of the ascending node (from xnodek within sgp4/sdp4)
+	double right_ascension;
+	///Current argument of perigee (from omgadf within sgp4/sdp4)
+	double argument_of_perigee;
+
 	///Which perturbation model to use
 	enum predict_ephemeris ephemeris;
 	///Ephemeris data structure pointer

--- a/include/predict/predict.h.in
+++ b/include/predict/predict.h.in
@@ -71,9 +71,24 @@ predict_julian_date_t predict_to_julian(time_t time);
 time_t predict_from_julian(predict_julian_date_t date);
 
 /**
+ * Simplified perturbation models used in modeling the satellite orbits.
+ **/
+enum predict_ephemeris {
+  EPHEMERIS_SGP4 = 0,
+  EPHEMERIS_SDP4 = 1,
+  EPHEMERIS_SGP8 = 2,
+  EPHEMERIS_SDP8 = 3
+};
+
+/**
  * Container for processed TLE data from TLE strings.
  **/
 typedef struct {
+	///Name of satellite
+	char name[128];
+	///Which perturbation model to use
+	enum predict_ephemeris ephemeris;
+
 	///Satellite number (line 1, field 2)
 	int satellite_number;
 	///Element number (line 1, field 13)
@@ -115,23 +130,11 @@ typedef struct {
  **/
 predict_orbital_elements_t predict_parse_tle(char *tle[2]);
 
-/**
- * Simplified perturbation models used in modeling the satellite orbits. 
- **/
-enum predict_ephemeris {
-  EPHEMERIS_SGP4 = 0,
-  EPHEMERIS_SDP4 = 1,
-  EPHEMERIS_SGP8 = 2,
-  EPHEMERIS_SDP8 = 3
-};
 
 /**
- * Satellite orbit definitions, according to defined NORAD TLE. 
+ * Predicted orbital values for satellite at a given time.
  **/
 typedef struct {
-	///Name of satellite
-	char name[128];
-
 	///Timestamp for last call to orbit_predict
 	predict_julian_date_t time;
 	///ECI position in km
@@ -155,11 +158,7 @@ typedef struct {
 	double phase;
 	///The current number of revolutions around Earth
 	long revolutions;
-	///Which perturbation model to use
-	enum predict_ephemeris ephemeris;
 
-	///Original predict_orbital_elements_t used to hold processed tle parameters used in calculations.
-	predict_orbital_elements_t orbital_elements;
 	///Ephemeris data structure pointer
 	void *ephemeris_data;
 } predict_orbit_t;
@@ -167,11 +166,10 @@ typedef struct {
 
 /**
  * Create orbit structure. Allocate memory and prepare internal data.
- * \param orbital_elements Processed NORAD two-line element set
  * \return Allocated orbit structure
  * \copyright GPLv2+
  **/
-predict_orbit_t *predict_create_orbit(predict_orbital_elements_t orbital_elements);
+predict_orbit_t *predict_create_orbit();
 
 /**
  * Free memory allocated in orbit structure. 
@@ -181,58 +179,60 @@ void predict_destroy_orbit(predict_orbit_t *orbit);
 
 /**
  * Main prediction function. Predict satellite orbit at given time. 
- * \param x Satellite orbit
+ * \param orbital_elements Orbital elements
+ * \param x Predicted orbit
  * \param time Julian day in UTC
  * \return 0 if everything went fine
  * \copyright GPLv2+
  **/
-int predict_orbit(predict_orbit_t *x, predict_julian_date_t time);
+int predict_orbit(const predict_orbital_elements_t *orbital_elements, predict_orbit_t *x, predict_julian_date_t time);
 
 /**
  * Find whether orbit is geostationary. 
  *
- * \param x Satellite orbit
+ * \param x Orbital elements
  * \return true if orbit is geostationary, otherwise false
  * \copyright GPLv2+
  **/
-bool predict_is_geostationary(const predict_orbit_t *x);
+bool predict_is_geostationary(const predict_orbital_elements_t *x);
 
 /** 
  * Get apogee of satellite orbit. 
  *
- * \param x Satellite orbit
+ * \param x Orbital elements
  * \return Apogee of orbit
  * \copyright GPLv2+
  **/
-double predict_apogee(const predict_orbit_t *x);
+double predict_apogee(const predict_orbital_elements_t *x);
 
 /**
  * Get perigee of satellite orbit. 
  *
- * \param x Satellite orbit
+ * \param x Orbital elements
  * \return Perigee of orbit
  * \copyright GPLv2+
  **/
-double predict_perigee(const predict_orbit_t *x);
+double predict_perigee(const predict_orbital_elements_t *x);
 
 /**
  * Find whether an AOS can ever happen on the given latitude. 
  *
- * \param x Satellite orbit
+ * \param x Orbital elements
  * \param latitude Latitude of ground station
  * \return true if AOS can happen, otherwise false
  * \copyright GPLv2+
  **/
-bool predict_aos_happens(const predict_orbit_t *x, double latitude);
+bool predict_aos_happens(const predict_orbital_elements_t *x, double latitude);
 
 /** 
  * Find whether an orbit has decayed.
  *
- * \param x Current state of orbit
+ * \param x Orbital elements
+ * \param time Time
  * \return true if orbit has decayed, otherwise false
  * \copyright GPLv2+
  **/
-bool predict_decayed(const predict_orbit_t *x);
+bool predict_decayed(const predict_orbital_elements_t *x, predict_julian_date_t time);
 
 /** 
  * Find whether a satellite is currently eclipsed.
@@ -344,23 +344,23 @@ void predict_observe_sun(const predict_observer_t *observer, predict_julian_date
  * Find next acquisition of signal (AOS) of satellite (when the satellite rises above the horizon). Ignores previous AOS of current pass if the satellite is in range at the start time. 
  *
  * \param observer Point of observation
- * \param orbit Satellite orbit
+ * \param orbital_elements Orbital elements
  * \param start_time Start time for AOS search
  * \return Time of AOS
  * \copyright GPLv2+
  **/
-predict_julian_date_t predict_next_aos(const predict_observer_t *observer, predict_orbit_t *orbit, predict_julian_date_t start_time);
+predict_julian_date_t predict_next_aos(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, predict_julian_date_t start_time);
 
 /** 
  * Find next loss of signal (LOS) of satellite (when the satellite goes below the horizon). Finds LOS of the current pass if the satellite currently is in range, finds LOS of next pass if not.
  *
  * \param observer Point of observation
- * \param orbit Satellite orbit
+ * \param orbital_elements Orbital elements
  * \param start_time Start time for LOS search
  * \return Time of LOS
  * \copyright GPLv2+
  **/
-predict_julian_date_t predict_next_los(const predict_observer_t *observer, predict_orbit_t *orbit, predict_julian_date_t start_time);
+predict_julian_date_t predict_next_los(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, predict_julian_date_t start_time);
 
 /**
  * Calculate doppler shift of a given downlink frequency with respect to the observer. 

--- a/include/predict/predict.h.in
+++ b/include/predict/predict.h.in
@@ -135,6 +135,10 @@ predict_orbital_elements_t predict_parse_tle(char *tle[2]);
 typedef struct {
 	///Timestamp for last call to orbit_predict
 	predict_julian_date_t time;
+
+	///Whether the orbit has decayed
+	bool decayed;
+
 	///ECI position in km
 	double position[3];
 	///ECI velocity in km/s
@@ -223,16 +227,6 @@ double predict_perigee(const predict_orbital_elements_t *x);
  * \copyright GPLv2+
  **/
 bool predict_aos_happens(const predict_orbital_elements_t *x, double latitude);
-
-/** 
- * Find whether an orbit has decayed.
- *
- * \param x Orbital elements
- * \param time Time
- * \return true if orbit has decayed, otherwise false
- * \copyright GPLv2+
- **/
-bool predict_decayed(const predict_orbital_elements_t *x, predict_julian_date_t time);
 
 /** 
  * Find whether a satellite is currently eclipsed.

--- a/src/libpredict.symver
+++ b/src/libpredict.symver
@@ -8,16 +8,13 @@ VER_0.1 {
 		predict_to_julian;
 		predict_from_julian;
 		predict_parse_tle;
-		predict_create_orbit;
-		predict_destroy_orbit;
+		predict_destroy_orbital_elements;
 		predict_orbit;
 		predict_is_geostationary;
 		predict_apogee;
 		predict_perigee;
 		predict_aos_happens;
 		predict_decayed;
-		predict_is_eclipsed;
-		predict_eclipse_depth;
 		predict_squint_angle;
 		predict_create_observer;
 		predict_destroy_observer;

--- a/src/observer.c
+++ b/src/observer.c
@@ -38,7 +38,7 @@ void predict_destroy_observer(predict_observer_t *obs)
  * Calculated range, azimuth, elevation and relative velocity from the
  * given observer position.
  **/
-void predict_observe_orbit(const predict_observer_t *observer, const predict_orbit_t *orbit, struct predict_observation *obs)
+void predict_observe_orbit(const predict_observer_t *observer, const struct predict_orbit *orbit, struct predict_observation *obs)
 {
 	if (obs == NULL) return;
 	
@@ -402,7 +402,7 @@ double predict_next_aos(const predict_observer_t *observer, const predict_orbita
 	struct predict_observation obs;
 	double time_step = 0;
 	
-	predict_orbit_t orbit;
+	struct predict_orbit orbit;
 	predict_orbit(orbital_elements, &orbit, curr_time);
 	predict_observe_orbit(observer, &orbit, &obs);
 
@@ -456,7 +456,7 @@ double predict_next_los(const predict_observer_t *observer, const predict_orbita
 	struct predict_observation obs;
 	double time_step = 0;
 
-	predict_orbit_t orbit;
+	struct predict_orbit orbit;
 	predict_orbit(orbital_elements, &orbit, curr_time);
 	predict_observe_orbit(observer, &orbit, &obs);
 
@@ -497,7 +497,7 @@ double predict_next_los(const predict_observer_t *observer, const predict_orbita
 
 }
 
-double predict_doppler_shift(const predict_observer_t *observer, const predict_orbit_t *orbit, double frequency)
+double predict_doppler_shift(const predict_observer_t *observer, const struct predict_orbit *orbit, double frequency)
 {
 	struct predict_observation obs;
 	predict_observe_orbit(observer, orbit, &obs);

--- a/src/observer.c
+++ b/src/observer.c
@@ -402,7 +402,7 @@ double predict_next_aos(const predict_observer_t *observer, const predict_orbita
 	struct predict_observation obs;
 	double time_step = 0;
 	
-	predict_orbit_t *orbit = predict_create_orbit(*orbital_elements);
+	predict_orbit_t *orbit = predict_create_orbit();
 	predict_orbit(orbital_elements, orbit, curr_time);
 	predict_observe_orbit(observer, orbit, &obs);
 
@@ -457,7 +457,7 @@ double predict_next_los(const predict_observer_t *observer, const predict_orbita
 	struct predict_observation obs;
 	double time_step = 0;
 
-	predict_orbit_t *orbit = predict_create_orbit(*orbital_elements);
+	predict_orbit_t *orbit = predict_create_orbit();
 	predict_orbit(orbital_elements, orbit, curr_time);
 	predict_observe_orbit(observer, orbit, &obs);
 

--- a/src/observer.c
+++ b/src/observer.c
@@ -407,7 +407,7 @@ double predict_next_aos(const predict_observer_t *observer, const predict_orbita
 	predict_observe_orbit(observer, orbit, &obs);
 
 	//check whether AOS can happen after specified start time
-	if (predict_aos_happens(orbital_elements, observer->latitude) && !predict_is_geostationary(orbital_elements) && !predict_decayed(orbital_elements, curr_time))
+	if (predict_aos_happens(orbital_elements, observer->latitude) && !predict_is_geostationary(orbital_elements) && orbit->decayed)
 	{
 		//TODO: Time steps have been found in FindAOS/LOS(). 
 		//Might be based on some pre-existing source, root-finding techniques
@@ -462,7 +462,7 @@ double predict_next_los(const predict_observer_t *observer, const predict_orbita
 	predict_observe_orbit(observer, orbit, &obs);
 
 	//check whether AOS/LOS can happen after specified start time
-	if (predict_aos_happens(orbital_elements, observer->latitude) && !predict_is_geostationary(orbital_elements) && !predict_decayed(orbital_elements, curr_time))
+	if (predict_aos_happens(orbital_elements, observer->latitude) && !predict_is_geostationary(orbital_elements) && !orbit->decayed)
 	{
 		//iterate until next satellite pass
 		if (obs.elevation < 0.0)

--- a/src/observer.c
+++ b/src/observer.c
@@ -402,12 +402,12 @@ double predict_next_aos(const predict_observer_t *observer, const predict_orbita
 	struct predict_observation obs;
 	double time_step = 0;
 	
-	predict_orbit_t *orbit = predict_create_orbit();
-	predict_orbit(orbital_elements, orbit, curr_time);
-	predict_observe_orbit(observer, orbit, &obs);
+	predict_orbit_t orbit;
+	predict_orbit(orbital_elements, &orbit, curr_time);
+	predict_observe_orbit(observer, &orbit, &obs);
 
 	//check whether AOS can happen after specified start time
-	if (predict_aos_happens(orbital_elements, observer->latitude) && !predict_is_geostationary(orbital_elements) && orbit->decayed)
+	if (predict_aos_happens(orbital_elements, observer->latitude) && !predict_is_geostationary(orbital_elements) && orbit.decayed)
 	{
 		//TODO: Time steps have been found in FindAOS/LOS(). 
 		//Might be based on some pre-existing source, root-finding techniques
@@ -422,31 +422,30 @@ double predict_next_aos(const predict_observer_t *observer, const predict_orbita
 		{
 			curr_time = predict_next_los(observer, orbital_elements, curr_time);
 			curr_time += DAYNUM_MINUTE*20; //skip 20 minutes. LOS might still be within the elevation threshold. (rough quickfix from predict) 
-			predict_orbit(orbital_elements, orbit, curr_time);
-			predict_observe_orbit(observer, orbit, &obs);
+			predict_orbit(orbital_elements, &orbit, curr_time);
+			predict_observe_orbit(observer, &orbit, &obs);
 		}
 
 		//iteration until the orbit is roughly in range again, before the satellite pass
 		while (obs.elevation*180.0/M_PI < -1.0)
 		{
-			time_step = 0.00035*(obs.elevation*180.0/M_PI*((orbit->altitude/8400.0)+0.46)-2.0);
+			time_step = 0.00035*(obs.elevation*180.0/M_PI*((orbit.altitude/8400.0)+0.46)-2.0);
 			curr_time -= time_step;
-			predict_orbit(orbital_elements, orbit, curr_time);
-			predict_observe_orbit(observer, orbit, &obs);
+			predict_orbit(orbital_elements, &orbit, curr_time);
+			predict_observe_orbit(observer, &orbit, &obs);
 		}
 
 		//fine tune the results until the elevation is within a low enough threshold
 		while (fabs(obs.elevation*180/M_PI) > ELEVATION_ZERO_TOLERANCE)
 		{
-			time_step = obs.elevation*180.0/M_PI*sqrt(orbit->altitude)/530000.0;
+			time_step = obs.elevation*180.0/M_PI*sqrt(orbit.altitude)/530000.0;
 			curr_time -= time_step;
-			predict_orbit(orbital_elements, orbit, curr_time);
-			predict_observe_orbit(observer, orbit, &obs);
+			predict_orbit(orbital_elements, &orbit, curr_time);
+			predict_observe_orbit(observer, &orbit, &obs);
 		}
 
 		ret_aos_time = curr_time;
 	}
-	predict_destroy_orbit(orbit);
 	return ret_aos_time;
 }
 
@@ -457,44 +456,43 @@ double predict_next_los(const predict_observer_t *observer, const predict_orbita
 	struct predict_observation obs;
 	double time_step = 0;
 
-	predict_orbit_t *orbit = predict_create_orbit();
-	predict_orbit(orbital_elements, orbit, curr_time);
-	predict_observe_orbit(observer, orbit, &obs);
+	predict_orbit_t orbit;
+	predict_orbit(orbital_elements, &orbit, curr_time);
+	predict_observe_orbit(observer, &orbit, &obs);
 
 	//check whether AOS/LOS can happen after specified start time
-	if (predict_aos_happens(orbital_elements, observer->latitude) && !predict_is_geostationary(orbital_elements) && !orbit->decayed)
+	if (predict_aos_happens(orbital_elements, observer->latitude) && !predict_is_geostationary(orbital_elements) && !orbit.decayed)
 	{
 		//iterate until next satellite pass
 		if (obs.elevation < 0.0)
 		{
 			curr_time = predict_next_aos(observer, orbital_elements, curr_time);
-			predict_orbit(orbital_elements, orbit, curr_time);
-			predict_observe_orbit(observer, orbit, &obs);
+			predict_orbit(orbital_elements, &orbit, curr_time);
+			predict_observe_orbit(observer, &orbit, &obs);
 		}
 
 		//step through the pass
 		do 
 		{
-			time_step = cos(obs.elevation - 1.0)*sqrt(orbit->altitude)/25000.0; 
+			time_step = cos(obs.elevation - 1.0)*sqrt(orbit.altitude)/25000.0;
 			curr_time += time_step;
-			predict_orbit(orbital_elements, orbit, curr_time);
-			predict_observe_orbit(observer, orbit, &obs);
+			predict_orbit(orbital_elements, &orbit, curr_time);
+			predict_observe_orbit(observer, &orbit, &obs);
 		} 
 		while (obs.elevation >= 0.0);
 		
 		//fine tune to elevation threshold
 		do 
 		{
-			time_step = obs.elevation*180.0/M_PI*sqrt(orbit->altitude)/502500.0;
+			time_step = obs.elevation*180.0/M_PI*sqrt(orbit.altitude)/502500.0;
 			curr_time += time_step;
-			predict_orbit(orbital_elements, orbit, curr_time);
-			predict_observe_orbit(observer, orbit, &obs);
+			predict_orbit(orbital_elements, &orbit, curr_time);
+			predict_observe_orbit(observer, &orbit, &obs);
 		}
 		while (fabs(obs.elevation*180.0/M_PI) > ELEVATION_ZERO_TOLERANCE);
 
 		ret_los_time = curr_time;
 	}
-	predict_destroy_orbit(orbit);
 	return ret_los_time;
 
 }

--- a/src/orbit.c
+++ b/src/orbit.c
@@ -156,7 +156,7 @@ bool predict_aos_happens(const predict_orbital_elements_t *m, double latitude)
 
 /* This is the stuff we need to do repetitively while tracking. */
 /* This is the old Calc() function. */
-int predict_orbit(const predict_orbital_elements_t *orbital_elements, predict_orbit_t *m, double utc)
+int predict_orbit(const predict_orbital_elements_t *orbital_elements, struct predict_orbit *m, double utc)
 {
 	/* Set time to now if now time is provided: */
 	if (utc == 0) utc = predict_to_julian(time(NULL));
@@ -264,17 +264,17 @@ bool is_eclipsed(const double pos[3], const double sol[3], double *depth)
 	else return false;
 }
 
-bool predict_is_eclipsed(const predict_orbit_t *orbit)
+bool predict_is_eclipsed(const struct predict_orbit *orbit)
 {
 	return orbit->eclipsed;
 }
 
-double predict_eclipse_depth(const predict_orbit_t *orbit)
+double predict_eclipse_depth(const struct predict_orbit *orbit)
 {
 	return orbit->eclipse_depth;
 }
 
-double predict_squint_angle(const predict_observer_t *observer, const predict_orbit_t *orbit, double alon, double alat)
+double predict_squint_angle(const predict_observer_t *observer, const struct predict_orbit *orbit, double alon, double alat)
 {
 	double bx = cos(alat)*cos(alon + orbit->argument_of_perigee);
 	double by = cos(alat)*sin(alon + orbit->argument_of_perigee);

--- a/src/orbit.c
+++ b/src/orbit.c
@@ -80,39 +80,6 @@ predict_orbital_elements_t* predict_parse_tle(char *tle[2])
 	return m;
 }
 
-predict_orbit_t *predict_create_orbit(predict_orbital_elements_t orbital_elements)
-{
-	// Allocate memory for new orbit struct
-	predict_orbit_t *m = (predict_orbit_t*)malloc(sizeof(predict_orbit_t));
-	if (m == NULL) return NULL;
-
-	m->time = nan("");
-	m->position[0] = nan("");
-	m->position[1] = nan("");
-	m->position[2] = nan("");
-	m->velocity[0] = nan("");
-	m->velocity[1] = nan("");
-	m->velocity[2] = nan("");
-	m->latitude = nan("");
-	m->longitude = nan("");
-	m->altitude = nan("");
-	m->eclipsed = false;
-	m->eclipse_depth = nan("");
-	m->footprint = nan("");
-	m->phase = nan("");
-	m->revolutions = 0;
-
-
-	return m;
-}
-
-void predict_destroy_orbit(predict_orbit_t *orbit)
-{
-	if (orbit == NULL) return;
-
-	free(orbit);
-}
-
 void predict_destroy_orbital_elements(predict_orbital_elements_t *m)
 {
 	if (m == NULL) return;

--- a/src/orbit.c
+++ b/src/orbit.c
@@ -85,7 +85,7 @@ predict_orbit_t *predict_create_orbit(predict_orbital_elements_t orbital_element
 			return NULL;
 		}
 		// Initialize ephemeris data structure
-		sdp4_init((struct _sdp4*)m->ephemeris_data);
+		sdp4_init(&orbital_elements, (struct _sdp4*)m->ephemeris_data);
 
 	} else {
 		m->ephemeris = EPHEMERIS_SGP4;

--- a/src/orbit.c
+++ b/src/orbit.c
@@ -98,7 +98,7 @@ predict_orbit_t *predict_create_orbit(predict_orbital_elements_t orbital_element
 			return NULL;
 		}
 		// Initialize ephemeris data structure
-		sgp4_init((struct _sgp4*)m->ephemeris_data);
+		sgp4_init(&orbital_elements, (struct _sgp4*)m->ephemeris_data);
 	}
 
 	return m;
@@ -205,8 +205,7 @@ int predict_orbit(const predict_orbital_elements_t *orbital_elements, predict_or
 			m->phase = ((struct _sdp4*)m->ephemeris_data)->phase;
 			break;
 		case EPHEMERIS_SGP4:
-			sgp4_predict((struct _sgp4*)m->ephemeris_data, tsince, orbital_elements, m->position, m->velocity);
-			m->phase = ((struct _sgp4*)m->ephemeris_data)->phase;
+			sgp4_predict((struct _sgp4*)m->ephemeris_data, tsince, m->position, m->velocity, &(m->phase));
 			break;
 		default:
 			//Panic!

--- a/src/orbit.c
+++ b/src/orbit.c
@@ -8,6 +8,7 @@
 #include "sun.h"
 
 bool is_eclipsed(const double pos[3], const double sol[3], double *depth);
+bool predict_decayed(const predict_orbital_elements_t *orbital_elements, predict_julian_date_t time);
 
 predict_orbital_elements_t predict_parse_tle(char *tle[2])
 {
@@ -239,6 +240,9 @@ int predict_orbit(const predict_orbital_elements_t *orbital_elements, predict_or
 	double xno = orbital_elements->mean_motion*temp*xmnpda;
 	double xmo = orbital_elements->mean_anomaly * M_PI / 180.0;
 	m->revolutions = (long)floor((xno*xmnpda/(M_PI*2.0) + age*orbital_elements->bstar_drag_term)*age + xmo/(2.0*M_PI)) + orbital_elements->revolutions_at_epoch;
+
+	//calculate whether orbit is decayed
+	m->decayed = predict_decayed(orbital_elements, utc);
 
 	return 0;
 }

--- a/src/orbit.c
+++ b/src/orbit.c
@@ -203,24 +203,24 @@ int predict_orbit(const predict_orbital_elements_t *orbital_elements, predict_or
 	switch (m->ephemeris) {
 		case EPHEMERIS_SDP4:
 			sdp4_predict((struct _sdp4*)m->ephemeris_data, tsince, orbital_elements, &output);
-			m->position[0] = output.pos[0];
-			m->position[1] = output.pos[1];
-			m->position[2] = output.pos[2];
-			m->velocity[0] = output.vel[0];
-			m->velocity[1] = output.vel[1];
-			m->velocity[2] = output.vel[2];
-			m->phase = output.phase;
-			m->argument_of_perigee = output.omgadf;
-			m->inclination = output.xinck;
-			m->right_ascension = output.xnodek;
 			break;
 		case EPHEMERIS_SGP4:
-			sgp4_predict((struct _sgp4*)m->ephemeris_data, tsince, m->position, m->velocity, &(m->phase));
+			sgp4_predict((struct _sgp4*)m->ephemeris_data, tsince, &output);
 			break;
 		default:
 			//Panic!
 			return -1;
 	}
+	m->position[0] = output.pos[0];
+	m->position[1] = output.pos[1];
+	m->position[2] = output.pos[2];
+	m->velocity[0] = output.vel[0];
+	m->velocity[1] = output.vel[1];
+	m->velocity[2] = output.vel[2];
+	m->phase = output.phase;
+	m->argument_of_perigee = output.omgadf;
+	m->inclination = output.xinck;
+	m->right_ascension = output.xnodek;
 
 	/* TODO: Remove? Scale position and velocity vectors to km and km/sec */
 	Convert_Sat_State(m->position, m->velocity);

--- a/src/orbit.c
+++ b/src/orbit.c
@@ -294,8 +294,8 @@ double predict_squint_angle(const predict_observer_t *observer, const predict_or
 	if (orbit->ephemeris == EPHEMERIS_SDP4) {
 		const struct _sdp4* sdp4 = (struct _sdp4*)orbit->ephemeris_data;
 
-		double bx = cos(alat)*cos(alon + sdp4->deep_arg.omgadf);
-		double by = cos(alat)*sin(alon + sdp4->deep_arg.omgadf);
+		double bx = cos(alat)*cos(alon + sdp4->deep_dyn.omgadf);
+		double by = cos(alat)*sin(alon + sdp4->deep_dyn.omgadf);
 		double bz = sin(alat);
 
 		double cx = bx;

--- a/src/orbit.c
+++ b/src/orbit.c
@@ -202,7 +202,7 @@ int predict_orbit(const predict_orbital_elements_t *orbital_elements, predict_or
 	struct model_output output;
 	switch (m->ephemeris) {
 		case EPHEMERIS_SDP4:
-			sdp4_predict((struct _sdp4*)m->ephemeris_data, tsince, orbital_elements, &output);
+			sdp4_predict((struct _sdp4*)m->ephemeris_data, tsince, &output);
 			break;
 		case EPHEMERIS_SGP4:
 			sgp4_predict((struct _sgp4*)m->ephemeris_data, tsince, &output);

--- a/src/sdp4.c
+++ b/src/sdp4.c
@@ -10,7 +10,23 @@
 #define DPSecular	1
 #define DPPeriodic	2
 
+/**
+ * Initialize the fixed part of deep_arg.
+ *
+ * \param tle Orbital elements
+ * \param m Initialized sdp4 model
+ * \param deep_arg Fixed part of deep_arg
+ * \copyright GPLv2+
+ **/
 void sdp4_deep_initialize(const predict_orbital_elements_t *tle, struct _sdp4 *m, deep_arg_fixed_t *deep_arg);
+
+/**
+ * Initialize the dynamic part of deep_arg.
+ *
+ * \param m Initialized sdp4 model
+ * \param deep_dyn Dynamic part of deep_arg
+ * \copyright GPLv2+
+ **/
 void deep_arg_dynamic_init(const struct _sdp4 *m, deep_arg_dynamic_t *deep_dyn);
 
 void sdp4_init(const predict_orbital_elements_t *tle, struct _sdp4 *m)

--- a/src/sdp4.c
+++ b/src/sdp4.c
@@ -21,7 +21,7 @@ void sdp4_init(struct _sdp4 *m)
 
 }
 
-void sdp4_predict(struct _sdp4 *m, double tsince, predict_orbital_elements_t * tle, double pos[3], double vel[3])
+void sdp4_predict(struct _sdp4 *m, double tsince, const predict_orbital_elements_t * tle, double pos[3], double vel[3])
 {
 	//Calculate old TLE field values as used in the original sdp4
 	double temp_tle = twopi/xmnpda/xmnpda;
@@ -281,7 +281,7 @@ double ThetaG(double epoch, deep_arg_t *deep_arg)
 	return ThetaG;
 }
 
-void sdp4_deep(struct _sdp4 *m, int ientry, predict_orbital_elements_t * tle, deep_arg_t * deep_arg)
+void sdp4_deep(struct _sdp4 *m, int ientry, const predict_orbital_elements_t * tle, deep_arg_t * deep_arg)
 {
 	/* This function is used by SDP4 to add lunar and solar */
 	/* perturbation effects to deep-space orbit objects.    */

--- a/src/sdp4.c
+++ b/src/sdp4.c
@@ -10,114 +10,112 @@
 #define DPSecular	1
 #define DPPeriodic	2
 
-void sdp4_init(struct _sdp4 *m)
+void sdp4_deep_initialize(const predict_orbital_elements_t *tle, struct _sdp4 *m, deep_arg_t *deep_arg);
+
+void sdp4_init(const predict_orbital_elements_t *tle, struct _sdp4 *m)
 {
-	m->initialized = 0;
 	m->lunarTermsDone = 0;
 	m->resonanceFlag = 0;
 	m->synchronousFlag = 0;
 	m->loopFlag = 0;
 	m->epochRestartFlag = 0;
 
+	/* Recover original mean motion (xnodp) and   */
+	/* semimajor axis (aodp) from input elements. */
+	double temp_tle = twopi/xmnpda/xmnpda;
+	double xincl = tle->inclination * M_PI / 180.0;
+	double eo = tle->eccentricity;
+	double xno = tle->mean_motion*temp_tle*xmnpda;
+	double bstar = tle->bstar_drag_term / ae;
+	double omegao = tle->argument_of_perigee * M_PI / 180.0;
+
+	double temp1, temp2, temp3, theta4, a1, a3ovk2, ao, c2, coef, coef1, x1m5th, xhdot1, del1, delo, eeta, eta, etasq, perigee, psisq, tsi, qoms24, s4, pinvsq;
+
+	a1=pow(xke/xno,tothrd);
+	m->deep_arg.cosio=cos(xincl);
+	m->deep_arg.theta2=m->deep_arg.cosio*m->deep_arg.cosio;
+	m->x3thm1=3*m->deep_arg.theta2-1;
+	m->deep_arg.eosq=eo*eo;
+	m->deep_arg.betao2=1-m->deep_arg.eosq;
+	m->deep_arg.betao=sqrt(m->deep_arg.betao2);
+	del1=1.5*ck2*m->x3thm1/(a1*a1*m->deep_arg.betao*m->deep_arg.betao2);
+	ao=a1*(1-del1*(0.5*tothrd+del1*(1+134/81*del1)));
+	delo=1.5*ck2*m->x3thm1/(ao*ao*m->deep_arg.betao*m->deep_arg.betao2);
+	m->deep_arg.xnodp=xno/(1+delo);
+	m->deep_arg.aodp=ao/(1-delo);
+
+	/* For perigee below 156 km, the values */
+	/* of s and qoms2t are altered.         */
+
+	s4=s;
+	qoms24=qoms2t;
+	perigee=(m->deep_arg.aodp*(1-eo)-ae)*xkmper;
+
+	if (perigee<156.0)
+	{
+		if (perigee<=98.0)
+			s4=20.0;
+		else
+			s4=perigee-78.0;
+
+		qoms24=pow((120-s4)*ae/xkmper,4);
+		s4=s4/xkmper+ae;
+	}
+
+	pinvsq=1/(m->deep_arg.aodp*m->deep_arg.aodp*m->deep_arg.betao2*m->deep_arg.betao2);
+	m->deep_arg.sing=sin(omegao);
+	m->deep_arg.cosg=cos(omegao);
+	tsi=1/(m->deep_arg.aodp-s4);
+	eta=m->deep_arg.aodp*eo*tsi;
+	etasq=eta*eta;
+	eeta=eo*eta;
+	psisq=fabs(1-etasq);
+	coef=qoms24*pow(tsi,4);
+	coef1=coef/pow(psisq,3.5);
+	c2=coef1*m->deep_arg.xnodp*(m->deep_arg.aodp*(1+1.5*etasq+eeta*(4+etasq))+0.75*ck2*tsi/psisq*m->x3thm1*(8+3*etasq*(8+etasq)));
+	m->c1=bstar*c2;
+	m->deep_arg.sinio=sin(xincl);
+	a3ovk2=-xj3/ck2*pow(ae,3);
+	m->x1mth2=1-m->deep_arg.theta2;
+	m->c4=2*m->deep_arg.xnodp*coef1*m->deep_arg.aodp*m->deep_arg.betao2*(eta*(2+0.5*etasq)+eo*(0.5+2*etasq)-2*ck2*tsi/(m->deep_arg.aodp*psisq)*(-3*m->x3thm1*(1-2*eeta+etasq*(1.5-0.5*eeta))+0.75*m->x1mth2*(2*etasq-eeta*(1+etasq))*cos(2*omegao)));
+	theta4=m->deep_arg.theta2*m->deep_arg.theta2;
+	temp1=3*ck2*pinvsq*m->deep_arg.xnodp;
+	temp2=temp1*ck2*pinvsq;
+	temp3=1.25*ck4*pinvsq*pinvsq*m->deep_arg.xnodp;
+	m->deep_arg.xmdot=m->deep_arg.xnodp+0.5*temp1*m->deep_arg.betao*m->x3thm1+0.0625*temp2*m->deep_arg.betao*(13-78*m->deep_arg.theta2+137*theta4);
+	x1m5th=1-5*m->deep_arg.theta2;
+	m->deep_arg.omgdot=-0.5*temp1*x1m5th+0.0625*temp2*(7-114*m->deep_arg.theta2+395*theta4)+temp3*(3-36*m->deep_arg.theta2+49*theta4);
+	xhdot1=-temp1*m->deep_arg.cosio;
+	m->deep_arg.xnodot=xhdot1+(0.5*temp2*(4-19*m->deep_arg.theta2)+2*temp3*(3-7*m->deep_arg.theta2))*m->deep_arg.cosio;
+	m->xnodcf=3.5*m->deep_arg.betao2*xhdot1*m->c1;
+	m->t2cof=1.5*m->c1;
+	m->xlcof=0.125*a3ovk2*m->deep_arg.sinio*(3+5*m->deep_arg.cosio)/(1+m->deep_arg.cosio);
+	m->aycof=0.25*a3ovk2*m->deep_arg.sinio;
+	m->x7thm1=7*m->deep_arg.theta2-1;
+
+	/* initialize Deep() */
+	sdp4_deep_initialize(tle, m, &(m->deep_arg));
 }
 
 void sdp4_predict(struct _sdp4 *m, double tsince, const predict_orbital_elements_t * tle, double pos[3], double vel[3])
 {
 	//Calculate old TLE field values as used in the original sdp4
-	double temp_tle = twopi/xmnpda/xmnpda;
 	double bstar = tle->bstar_drag_term / ae;
-	double xincl = tle->inclination * M_PI / 180.0;
 	double xnodeo = tle->right_ascension * M_PI / 180.0;
-	double eo = tle->eccentricity;
 	double omegao = tle->argument_of_perigee * M_PI / 180.0;
 	double xmo = tle->mean_anomaly * M_PI / 180.0;
-	double xno = tle->mean_motion*temp_tle*xmnpda;
 
 	int i;
 	double a, axn, ayn, aynl, beta, betal, capu, cos2u, cosepw, cosik,
-	cosnok, cosu, cosuk, ecose, elsq, epw, esine, pl, theta4, rdot,
+	cosnok, cosu, cosuk, ecose, elsq, epw, esine, pl,
+	rdot,
 	rdotk, rfdot, rfdotk, rk, sin2u, sinepw, sinik, sinnok, sinu,
 	sinuk, tempe, templ, tsq, u, uk, ux, uy, uz, vx, vy, vz, xl,
-	xlt, xmam, xmdf, xmx, xmy, xnoddf, xll, a1, a3ovk2, ao, c2,
-	coef, coef1, x1m5th, xhdot1, del1, r, delo, eeta, eta, etasq,
-	perigee, psisq, tsi, qoms24, s4, pinvsq, temp, tempa, temp1,
+	xlt, xmam, xmdf, xmx, xmy, xnoddf, xll,
+	r,
+	temp, tempa, temp1,
 	temp2, temp3, temp4, temp5, temp6;
 
-	/* Initialization (if flag not set) */
-	if (!m->initialized) {
-		
-		//Set initialized flag:
-		m->initialized = true;
-
-		/* Recover original mean motion (xnodp) and   */
-		/* semimajor axis (aodp) from input elements. */
-	  
-		a1=pow(xke/xno,tothrd);
-		m->deep_arg.cosio=cos(xincl);
-		m->deep_arg.theta2=m->deep_arg.cosio*m->deep_arg.cosio;
-		m->x3thm1=3*m->deep_arg.theta2-1;
-		m->deep_arg.eosq=eo*eo;
-		m->deep_arg.betao2=1-m->deep_arg.eosq;
-		m->deep_arg.betao=sqrt(m->deep_arg.betao2);
-		del1=1.5*ck2*m->x3thm1/(a1*a1*m->deep_arg.betao*m->deep_arg.betao2);
-		ao=a1*(1-del1*(0.5*tothrd+del1*(1+134/81*del1)));
-		delo=1.5*ck2*m->x3thm1/(ao*ao*m->deep_arg.betao*m->deep_arg.betao2);
-		m->deep_arg.xnodp=xno/(1+delo);
-		m->deep_arg.aodp=ao/(1-delo);
-
-		/* For perigee below 156 km, the values */
-		/* of s and qoms2t are altered.         */
-	  
-		s4=s;
-		qoms24=qoms2t;
-		perigee=(m->deep_arg.aodp*(1-eo)-ae)*xkmper;
-	  
-		if (perigee<156.0)
-		{
-			if (perigee<=98.0)
-				s4=20.0;
-			else
-				s4=perigee-78.0;
-	
-			qoms24=pow((120-s4)*ae/xkmper,4);
-			s4=s4/xkmper+ae;
-		}
-
-		pinvsq=1/(m->deep_arg.aodp*m->deep_arg.aodp*m->deep_arg.betao2*m->deep_arg.betao2);
-		m->deep_arg.sing=sin(omegao);
-		m->deep_arg.cosg=cos(omegao);
-		tsi=1/(m->deep_arg.aodp-s4);
-		eta=m->deep_arg.aodp*eo*tsi;
-		etasq=eta*eta;
-		eeta=eo*eta;
-		psisq=fabs(1-etasq);
-		coef=qoms24*pow(tsi,4);
-		coef1=coef/pow(psisq,3.5);
-		c2=coef1*m->deep_arg.xnodp*(m->deep_arg.aodp*(1+1.5*etasq+eeta*(4+etasq))+0.75*ck2*tsi/psisq*m->x3thm1*(8+3*etasq*(8+etasq)));
-		m->c1=bstar*c2;
-		m->deep_arg.sinio=sin(xincl);
-		a3ovk2=-xj3/ck2*pow(ae,3);
-		m->x1mth2=1-m->deep_arg.theta2;
-		m->c4=2*m->deep_arg.xnodp*coef1*m->deep_arg.aodp*m->deep_arg.betao2*(eta*(2+0.5*etasq)+eo*(0.5+2*etasq)-2*ck2*tsi/(m->deep_arg.aodp*psisq)*(-3*m->x3thm1*(1-2*eeta+etasq*(1.5-0.5*eeta))+0.75*m->x1mth2*(2*etasq-eeta*(1+etasq))*cos(2*omegao)));
-		theta4=m->deep_arg.theta2*m->deep_arg.theta2;
-		temp1=3*ck2*pinvsq*m->deep_arg.xnodp;
-		temp2=temp1*ck2*pinvsq;
-		temp3=1.25*ck4*pinvsq*pinvsq*m->deep_arg.xnodp;
-		m->deep_arg.xmdot=m->deep_arg.xnodp+0.5*temp1*m->deep_arg.betao*m->x3thm1+0.0625*temp2*m->deep_arg.betao*(13-78*m->deep_arg.theta2+137*theta4);
-		x1m5th=1-5*m->deep_arg.theta2;
-		m->deep_arg.omgdot=-0.5*temp1*x1m5th+0.0625*temp2*(7-114*m->deep_arg.theta2+395*theta4)+temp3*(3-36*m->deep_arg.theta2+49*theta4);
-		xhdot1=-temp1*m->deep_arg.cosio;
-		m->deep_arg.xnodot=xhdot1+(0.5*temp2*(4-19*m->deep_arg.theta2)+2*temp3*(3-7*m->deep_arg.theta2))*m->deep_arg.cosio;
-		m->xnodcf=3.5*m->deep_arg.betao2*xhdot1*m->c1;
-		m->t2cof=1.5*m->c1;
-		m->xlcof=0.125*a3ovk2*m->deep_arg.sinio*(3+5*m->deep_arg.cosio)/(1+m->deep_arg.cosio);
-		m->aycof=0.25*a3ovk2*m->deep_arg.sinio;
-		m->x7thm1=7*m->deep_arg.theta2-1;
-
-		/* initialize Deep() */
-		sdp4_deep(m, DPInit,tle,&m->deep_arg);
-	}
-		
 	/* Update for secular gravity and atmospheric drag */
 	xmdf=xmo+m->deep_arg.xmdot*tsince;
 	m->deep_arg.omgadf=omegao+m->deep_arg.omgdot*tsince;
@@ -172,14 +170,14 @@ void sdp4_predict(struct _sdp4 *m, double tsince, const predict_orbital_elements
 		temp5=axn*cosepw;
 		temp6=ayn*sinepw;
 		epw=(capu-temp4+temp3-temp2)/(1-temp5-temp6)+temp2;
-	  
+
 		if (fabs(epw-temp2)<=e6a)
 			break;
 
 		temp2=epw;
-	  
+
 	} while (i++<10);
-		
+
 	/* Short period preliminary quantities */
 	ecose=temp5+temp6;
 	esine=temp3-temp4;
@@ -236,7 +234,7 @@ void sdp4_predict(struct _sdp4 *m, double tsince, const predict_orbital_elements
 
 	/* Phase in radians */
 	m->phase=xlt-m->deep_arg.xnode-m->deep_arg.omgadf+twopi;
-    
+
 	if (m->phase<0.0)
 		m->phase+=twopi;
 
@@ -245,10 +243,10 @@ void sdp4_predict(struct _sdp4 *m, double tsince, const predict_orbital_elements
 
 /**
  * Calculates the Greenwich Mean Sidereal Time
- * for an epoch specified in the format used in the NORAD two-line 
- * element sets. 
+ * for an epoch specified in the format used in the NORAD two-line
+ * element sets.
  * It has been adapted for dates beyond the year 1999.
- * Reference:  The 1992 Astronomical Almanac, page B6. 
+ * Reference:  The 1992 Astronomical Almanac, page B6.
  * Modification to support Y2K. Valid 1957 through 2056.
  *
  * \param epoch TLE epoch
@@ -281,11 +279,8 @@ double ThetaG(double epoch, deep_arg_t *deep_arg)
 	return ThetaG;
 }
 
-void sdp4_deep(struct _sdp4 *m, int ientry, const predict_orbital_elements_t * tle, deep_arg_t * deep_arg)
+void sdp4_deep_initialize(const predict_orbital_elements_t *tle, struct _sdp4 *m, deep_arg_t *deep_arg)
 {
-	/* This function is used by SDP4 to add lunar and solar */
-	/* perturbation effects to deep-space orbit objects.    */
-
 	//Calculate old TLE field values as used in the original sdp4
 	double epoch = 1000.0*tle->epoch_year + tle->epoch_day;
 	double xincl = tle->inclination * M_PI / 180.0;
@@ -294,311 +289,330 @@ void sdp4_deep(struct _sdp4 *m, int ientry, const predict_orbital_elements_t * t
 	double omegao = tle->argument_of_perigee * M_PI / 180.0;
 	double xmo = tle->mean_anomaly * M_PI / 180.0;
 
-	double a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, ainv2, alfdp, aqnv,
-	sgh, sini2, sinis, sinok, sh, si, sil, day, betdp, dalf, bfact, c,
-	cc, cosis, cosok, cosq, ctem, f322, zx, zy, dbet, dls, eoc, eq, f2,
-	f220, f221, f3, f311, f321, xnoh, f330, f441, f442, f522, f523,
-	f542, f543, g200, g201, g211, pgh, ph, s1, s2, s3, s4, s5, s6, s7,
-	se, sel, ses, xls, g300, g310, g322, g410, g422, g520, g521, g532,
-	g533, gam, sinq, sinzf, sis, sl, sll, sls, stem, temp, temp1, x1,
-	x2, x2li, x2omi, x3, x4, x5, x6, x7, x8, xl, xldot, xmao, xnddt,
-	xndot, xno2, xnodce, xnoi, xomi, xpidot, z1, z11, z12, z13, z2,
-	  z21, z22, z23, z3, z31, z32, z33, ze, zf, zm, /*zmo,*/ zn, zsing,
-	zsinh, zsini, zcosg, zcosh, zcosi, delt=0, ft=0;
+	double a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, ainv2, aqnv,
+	sgh, sini2, sh, si, day, bfact, c,
+	cc, cosq, ctem, f322, zx, zy, eoc, eq,
+	f220, f221, f311, f321, f330, f441, f442, f522, f523,
+	f542, f543, g200, g201, g211, s1, s2, s3, s4, s5, s6, s7,
+	se, g300, g310, g322, g410, g422, g520, g521, g532,
+	g533, gam, sinq, sl, stem, temp, temp1, x1,
+	x2, x3, x4, x5, x6, x7, x8, xmao,
+	xno2, xnodce, xnoi, xpidot, z1, z11, z12, z13, z2,
+	z21, z22, z23, z3, z31, z32, z33, ze, zn, zsing,
+	zsinh, zsini, zcosg, zcosh, zcosi;
+
+	/* Entrance for deep space initialization */
+	m->thgr=ThetaG(epoch,deep_arg);
+	eq=eo;
+	m->xnq=deep_arg->xnodp;
+	aqnv=1/deep_arg->aodp;
+	m->xqncl=xincl;
+	xmao=xmo;
+	xpidot=deep_arg->omgdot+deep_arg->xnodot;
+	sinq=sin(xnodeo);
+	cosq=cos(xnodeo);
+	m->omegaq=omegao;
+
+	/* Initialize lunar solar terms */
+	day=deep_arg->ds50+18261.5;  /* Days since 1900 Jan 0.5 */
+
+	if (day!=m->preep)
+	{
+		m->preep=day;
+		xnodce=4.5236020-9.2422029E-4*day;
+		stem=sin(xnodce);
+		ctem=cos(xnodce);
+		m->zcosil=0.91375164-0.03568096*ctem;
+		m->zsinil=sqrt(1-m->zcosil*m->zcosil);
+		m->zsinhl=0.089683511*stem/m->zsinil;
+		m->zcoshl=sqrt(1-m->zsinhl*m->zsinhl);
+		c=4.7199672+0.22997150*day;
+		gam=5.8351514+0.0019443680*day;
+		m->zmol=FMod2p(c-gam);
+		zx=0.39785416*stem/m->zsinil;
+		zy=m->zcoshl*ctem+0.91744867*m->zsinhl*stem;
+		zx=AcTan(zx,zy);
+		zx=gam+zx-xnodce;
+		m->zcosgl=cos(zx);
+		m->zsingl=sin(zx);
+		m->zmos=6.2565837+0.017201977*day;
+		m->zmos=FMod2p(m->zmos);
+	    }
+
+	  /* Do solar terms */
+	  m->savtsn=1E20;
+	  zcosg=zcosgs;
+	  zsing=zsings;
+	  zcosi=zcosis;
+	  zsini=zsinis;
+	  zcosh=cosq;
+	  zsinh= sinq;
+	  cc=c1ss;
+	  zn=zns;
+	  ze=zes;
+	  /* zmo=m->zmos; */
+	  xnoi=1/m->xnq;
+
+	  /* Loop breaks when Solar terms are done a second */
+	  /* time, after Lunar terms are initialized        */
+
+	for (;;)
+	{
+		/* Solar terms done again after Lunar terms are done */
+		a1=zcosg*zcosh+zsing*zcosi*zsinh;
+		a3=-zsing*zcosh+zcosg*zcosi*zsinh;
+		a7=-zcosg*zsinh+zsing*zcosi*zcosh;
+		a8=zsing*zsini;
+		a9=zsing*zsinh+zcosg*zcosi*zcosh;
+		a10=zcosg*zsini;
+		a2=deep_arg->cosio*a7+deep_arg->sinio*a8;
+		a4=deep_arg->cosio*a9+deep_arg->sinio*a10;
+		a5=-deep_arg->sinio*a7+deep_arg->cosio*a8;
+		a6=-deep_arg->sinio*a9+deep_arg->cosio*a10;
+		x1=a1*deep_arg->cosg+a2*deep_arg->sing;
+		x2=a3*deep_arg->cosg+a4*deep_arg->sing;
+		x3=-a1*deep_arg->sing+a2*deep_arg->cosg;
+		x4=-a3*deep_arg->sing+a4*deep_arg->cosg;
+		x5=a5*deep_arg->sing;
+		x6=a6*deep_arg->sing;
+		x7=a5*deep_arg->cosg;
+		x8=a6*deep_arg->cosg;
+		z31=12*x1*x1-3*x3*x3;
+		z32=24*x1*x2-6*x3*x4;
+		z33=12*x2*x2-3*x4*x4;
+		z1=3*(a1*a1+a2*a2)+z31*deep_arg->eosq;
+		z2=6*(a1*a3+a2*a4)+z32*deep_arg->eosq;
+		z3=3*(a3*a3+a4*a4)+z33*deep_arg->eosq;
+		z11=-6*a1*a5+deep_arg->eosq*(-24*x1*x7-6*x3*x5);
+		z12=-6*(a1*a6+a3*a5)+deep_arg->eosq*(-24*(x2*x7+x1*x8)-6*(x3*x6+x4*x5));
+		z13=-6*a3*a6+deep_arg->eosq*(-24*x2*x8-6*x4*x6);
+		z21=6*a2*a5+deep_arg->eosq*(24*x1*x5-6*x3*x7);
+		z22=6*(a4*a5+a2*a6)+deep_arg->eosq*(24*(x2*x5+x1*x6)-6*(x4*x7+x3*x8));
+		z23=6*a4*a6+deep_arg->eosq*(24*x2*x6-6*x4*x8);
+		z1=z1+z1+deep_arg->betao2*z31;
+		z2=z2+z2+deep_arg->betao2*z32;
+		z3=z3+z3+deep_arg->betao2*z33;
+		s3=cc*xnoi;
+		s2=-0.5*s3/deep_arg->betao;
+		s4=s3*deep_arg->betao;
+		s1=-15*eq*s4;
+		s5=x1*x3+x2*x4;
+		s6=x2*x3+x1*x4;
+		s7=x2*x4-x1*x3;
+		se=s1*zn*s5;
+		si=s2*zn*(z11+z13);
+		sl=-zn*s3*(z1+z3-14-6*deep_arg->eosq);
+		sgh=s4*zn*(z31+z33-6);
+		sh=-zn*s2*(z21+z23);
+
+		if (m->xqncl<5.2359877E-2)
+			sh=0;
+
+		m->ee2=2*s1*s6;
+		m->e3=2*s1*s7;
+		m->xi2=2*s2*z12;
+		m->xi3=2*s2*(z13-z11);
+		m->xl2=-2*s3*z2;
+		m->xl3=-2*s3*(z3-z1);
+		m->xl4=-2*s3*(-21-9*deep_arg->eosq)*ze;
+		m->xgh2=2*s4*z32;
+		m->xgh3=2*s4*(z33-z31);
+		m->xgh4=-18*s4*ze;
+		m->xh2=-2*s2*z22;
+		m->xh3=-2*s2*(z23-z21);
+
+		//Skip lunar terms?
+		if (m->lunarTermsDone) {
+			break;
+		}
+
+		/* Do lunar terms */
+		m->sse=se;
+		m->ssi=si;
+		m->ssl=sl;
+		m->ssh=sh/deep_arg->sinio;
+		m->ssg=sgh-deep_arg->cosio*m->ssh;
+		m->se2=m->ee2;
+		m->si2=m->xi2;
+		m->sl2=m->xl2;
+		m->sgh2=m->xgh2;
+		m->sh2=m->xh2;
+		m->se3=m->e3;
+		m->si3=m->xi3;
+		m->sl3=m->xl3;
+		m->sgh3=m->xgh3;
+		m->sh3=m->xh3;
+		m->sl4=m->xl4;
+		m->sgh4=m->xgh4;
+		zcosg=m->zcosgl;
+		zsing=m->zsingl;
+		zcosi=m->zcosil;
+		zsini=m->zsinil;
+		zcosh=m->zcoshl*cosq+m->zsinhl*sinq;
+		zsinh=sinq*m->zcoshl-cosq*m->zsinhl;
+		zn=znl;
+		cc=c1l;
+		ze=zel;
+		/* zmo=m->zmol; */
+		//Set lunarTermsDone flag:
+		m->lunarTermsDone = true;
+	}
+
+	m->sse=m->sse+se;
+	m->ssi=m->ssi+si;
+	m->ssl=m->ssl+sl;
+	m->ssg=m->ssg+sgh-deep_arg->cosio/deep_arg->sinio*sh;
+	m->ssh=m->ssh+sh/deep_arg->sinio;
+
+	/* Geopotential resonance initialization for 12 hour orbits */
+	m->resonanceFlag = 0;
+	m->synchronousFlag = 0;
+
+	if (!((m->xnq<0.0052359877) && (m->xnq>0.0034906585)))
+	{
+		if ((m->xnq<0.00826) || (m->xnq>0.00924))
+		    return;
+
+		if (eq<0.5)
+		    return;
+
+		m->resonanceFlag = 1;
+		eoc=eq*deep_arg->eosq;
+		g201=-0.306-(eq-0.64)*0.440;
+
+		if (eq<=0.65)
+		{
+			g211=3.616-13.247*eq+16.290*deep_arg->eosq;
+			g310=-19.302+117.390*eq-228.419*deep_arg->eosq+156.591*eoc;
+			g322=-18.9068+109.7927*eq-214.6334*deep_arg->eosq+146.5816*eoc;
+			g410=-41.122+242.694*eq-471.094*deep_arg->eosq+313.953*eoc;
+			g422=-146.407+841.880*eq-1629.014*deep_arg->eosq+1083.435 * eoc;
+			g520=-532.114+3017.977*eq-5740*deep_arg->eosq+3708.276*eoc;
+		}
+
+		else
+		{
+			g211=-72.099+331.819*eq-508.738*deep_arg->eosq+266.724*eoc;
+			g310=-346.844+1582.851*eq-2415.925*deep_arg->eosq+1246.113*eoc;
+			g322=-342.585+1554.908*eq-2366.899*deep_arg->eosq+1215.972*eoc;
+			g410=-1052.797+4758.686*eq-7193.992*deep_arg->eosq+3651.957*eoc;
+			g422=-3581.69+16178.11*eq-24462.77*deep_arg->eosq+12422.52*eoc;
+
+			if (eq<=0.715)
+				g520=1464.74-4664.75*eq+3763.64*deep_arg->eosq;
+
+			else
+				g520=-5149.66+29936.92*eq-54087.36*deep_arg->eosq+31324.56*eoc;
+		}
+
+		if (eq<0.7)
+		{
+			g533=-919.2277+4988.61*eq-9064.77*deep_arg->eosq+5542.21*eoc;
+			g521=-822.71072+4568.6173*eq-8491.4146*deep_arg->eosq+5337.524*eoc;
+			g532=-853.666+4690.25*eq-8624.77*deep_arg->eosq+5341.4*eoc;
+		}
+
+		else
+		{
+			g533=-37995.78+161616.52*eq-229838.2*deep_arg->eosq+109377.94*eoc;
+			g521 =-51752.104+218913.95*eq-309468.16*deep_arg->eosq+146349.42*eoc;
+			g532 =-40023.88+170470.89*eq-242699.48*deep_arg->eosq+115605.82*eoc;
+		}
+
+		sini2=deep_arg->sinio*deep_arg->sinio;
+		f220=0.75*(1+2*deep_arg->cosio+deep_arg->theta2);
+		f221=1.5*sini2;
+		f321=1.875*deep_arg->sinio*(1-2*deep_arg->cosio-3*deep_arg->theta2);
+		f322=-1.875*deep_arg->sinio*(1+2*deep_arg->cosio-3*deep_arg->theta2);
+		f441=35*sini2*f220;
+		f442=39.3750*sini2*sini2;
+		f522=9.84375*deep_arg->sinio*(sini2*(1-2*deep_arg->cosio-5*deep_arg->theta2)+0.33333333*(-2+4*deep_arg->cosio+6*deep_arg->theta2));
+		f523=deep_arg->sinio*(4.92187512*sini2*(-2-4*deep_arg->cosio+10*deep_arg->theta2)+6.56250012*(1+2*deep_arg->cosio-3*deep_arg->theta2));
+		f542=29.53125*deep_arg->sinio*(2-8*deep_arg->cosio+deep_arg->theta2*(-12+8*deep_arg->cosio+10*deep_arg->theta2));
+		f543=29.53125*deep_arg->sinio*(-2-8*deep_arg->cosio+deep_arg->theta2*(12+8*deep_arg->cosio-10*deep_arg->theta2));
+		xno2=m->xnq*m->xnq;
+		ainv2=aqnv*aqnv;
+		temp1=3*xno2*ainv2;
+		temp=temp1*root22;
+		m->d2201=temp*f220*g201;
+		m->d2211=temp*f221*g211;
+		temp1=temp1*aqnv;
+		temp=temp1*root32;
+		m->d3210=temp*f321*g310;
+		m->d3222=temp*f322*g322;
+		temp1=temp1*aqnv;
+		temp=2*temp1*root44;
+		m->d4410=temp*f441*g410;
+		m->d4422=temp*f442*g422;
+		temp1=temp1*aqnv;
+		temp=temp1*root52;
+		m->d5220=temp*f522*g520;
+		m->d5232=temp*f523*g532;
+		temp=2*temp1*root54;
+		m->d5421=temp*f542*g521;
+		m->d5433=temp*f543*g533;
+		m->xlamo=xmao+xnodeo+xnodeo-m->thgr-m->thgr;
+		bfact=deep_arg->xmdot+deep_arg->xnodot+deep_arg->xnodot-thdt-thdt;
+		bfact=bfact+m->ssl+m->ssh+m->ssh;
+	}
+
+	else
+	{
+		m->resonanceFlag = 1;
+		m->synchronousFlag = 1;
+
+		/* Synchronous resonance terms initialization */
+		g200=1+deep_arg->eosq*(-2.5+0.8125*deep_arg->eosq);
+		g310=1+2*deep_arg->eosq;
+		g300=1+deep_arg->eosq*(-6+6.60937*deep_arg->eosq);
+		f220=0.75*(1+deep_arg->cosio)*(1+deep_arg->cosio);
+		f311=0.9375*deep_arg->sinio*deep_arg->sinio*(1+3*deep_arg->cosio)-0.75*(1+deep_arg->cosio);
+		f330=1+deep_arg->cosio;
+		f330=1.875*f330*f330*f330;
+		m->del1=3*m->xnq*m->xnq*aqnv*aqnv;
+		m->del2=2*m->del1*f220*g200*q22;
+		m->del3=3*m->del1*f330*g300*q33*aqnv;
+		m->del1=m->del1*f311*g310*q31*aqnv;
+		m->fasx2=0.13130908;
+		m->fasx4=2.8843198;
+		m->fasx6=0.37448087;
+		m->xlamo=xmao+xnodeo+omegao-m->thgr;
+		bfact=deep_arg->xmdot+xpidot-thdt;
+		bfact=bfact+m->ssl+m->ssg+m->ssh;
+	}
+
+	m->xfact=bfact-m->xnq;
+
+	/* Initialize integrator */
+	m->xli=m->xlamo;
+	m->xni=m->xnq;
+	m->atime=0;
+	m->stepp=720;
+	m->stepn=-720;
+	m->step2=259200;
+
+	return;
+}
+
+void sdp4_deep(struct _sdp4 *m, int ientry, const predict_orbital_elements_t * tle, deep_arg_t * deep_arg)
+{
+	/* This function is used by SDP4 to add lunar and solar */
+	/* perturbation effects to deep-space orbit objects.    */
+
+	//Calculate old TLE field values as used in the original sdp4
+	double xincl = tle->inclination * M_PI / 180.0;
+	double eo = tle->eccentricity;
+
+	double alfdp,
+	sinis, sinok, sil, betdp, dalf, cosis, cosok, dbet, dls, f2,
+	f3, xnoh, pgh, ph, sel, ses, xls, sinzf, sis, sll, sls, temp,
+	x2li, x2omi, xl, xldot, xnddt,
+	xndot, xomi, zf, zm,
+	delt=0, ft=0;
+
 
 	switch (ientry)
 	{
-		case DPInit:  /* Entrance for deep space initialization */
-		m->thgr=ThetaG(epoch,deep_arg);
-		eq=eo;
-		m->xnq=deep_arg->xnodp;
-		aqnv=1/deep_arg->aodp;
-		m->xqncl=xincl;
-		xmao=xmo;
-		xpidot=deep_arg->omgdot+deep_arg->xnodot;
-		sinq=sin(xnodeo);
-		cosq=cos(xnodeo);
-		m->omegaq=omegao;
-
-		/* Initialize lunar solar terms */
-		day=deep_arg->ds50+18261.5;  /* Days since 1900 Jan 0.5 */
-	  
-		if (day!=m->preep)
-		{
-			m->preep=day;
-			xnodce=4.5236020-9.2422029E-4*day;
-			stem=sin(xnodce);
-			ctem=cos(xnodce);
-			m->zcosil=0.91375164-0.03568096*ctem;
-			m->zsinil=sqrt(1-m->zcosil*m->zcosil);
-			m->zsinhl=0.089683511*stem/m->zsinil;
-			m->zcoshl=sqrt(1-m->zsinhl*m->zsinhl);
-			c=4.7199672+0.22997150*day;
-			gam=5.8351514+0.0019443680*day;
-			m->zmol=FMod2p(c-gam);
-			zx=0.39785416*stem/m->zsinil;
-			zy=m->zcoshl*ctem+0.91744867*m->zsinhl*stem;
-			zx=AcTan(zx,zy);
-			zx=gam+zx-xnodce;
-			m->zcosgl=cos(zx);
-			m->zsingl=sin(zx);
-			m->zmos=6.2565837+0.017201977*day;
-			m->zmos=FMod2p(m->zmos);
-		    }
-
-		  /* Do solar terms */
-		  m->savtsn=1E20;
-		  zcosg=zcosgs;
-		  zsing=zsings;
-		  zcosi=zcosis;
-		  zsini=zsinis;
-		  zcosh=cosq;
-		  zsinh= sinq;
-		  cc=c1ss;
-		  zn=zns;
-		  ze=zes;
-		  /* zmo=m->zmos; */
-		  xnoi=1/m->xnq;
-
-		  /* Loop breaks when Solar terms are done a second */
-		  /* time, after Lunar terms are initialized        */
-	  
-		for (;;)
-		{
-			/* Solar terms done again after Lunar terms are done */
-			a1=zcosg*zcosh+zsing*zcosi*zsinh;
-			a3=-zsing*zcosh+zcosg*zcosi*zsinh;
-			a7=-zcosg*zsinh+zsing*zcosi*zcosh;
-			a8=zsing*zsini;
-			a9=zsing*zsinh+zcosg*zcosi*zcosh;
-			a10=zcosg*zsini;
-			a2=deep_arg->cosio*a7+deep_arg->sinio*a8;
-			a4=deep_arg->cosio*a9+deep_arg->sinio*a10;
-			a5=-deep_arg->sinio*a7+deep_arg->cosio*a8;
-			a6=-deep_arg->sinio*a9+deep_arg->cosio*a10;
-			x1=a1*deep_arg->cosg+a2*deep_arg->sing;
-			x2=a3*deep_arg->cosg+a4*deep_arg->sing;
-			x3=-a1*deep_arg->sing+a2*deep_arg->cosg;
-			x4=-a3*deep_arg->sing+a4*deep_arg->cosg;
-			x5=a5*deep_arg->sing;
-			x6=a6*deep_arg->sing;
-			x7=a5*deep_arg->cosg;
-			x8=a6*deep_arg->cosg;
-			z31=12*x1*x1-3*x3*x3;
-			z32=24*x1*x2-6*x3*x4;
-			z33=12*x2*x2-3*x4*x4;
-			z1=3*(a1*a1+a2*a2)+z31*deep_arg->eosq;
-			z2=6*(a1*a3+a2*a4)+z32*deep_arg->eosq;
-			z3=3*(a3*a3+a4*a4)+z33*deep_arg->eosq;
-			z11=-6*a1*a5+deep_arg->eosq*(-24*x1*x7-6*x3*x5);
-			z12=-6*(a1*a6+a3*a5)+deep_arg->eosq*(-24*(x2*x7+x1*x8)-6*(x3*x6+x4*x5));
-			z13=-6*a3*a6+deep_arg->eosq*(-24*x2*x8-6*x4*x6);
-			z21=6*a2*a5+deep_arg->eosq*(24*x1*x5-6*x3*x7);
-			z22=6*(a4*a5+a2*a6)+deep_arg->eosq*(24*(x2*x5+x1*x6)-6*(x4*x7+x3*x8));
-			z23=6*a4*a6+deep_arg->eosq*(24*x2*x6-6*x4*x8);
-			z1=z1+z1+deep_arg->betao2*z31;
-			z2=z2+z2+deep_arg->betao2*z32;
-			z3=z3+z3+deep_arg->betao2*z33;
-			s3=cc*xnoi;
-			s2=-0.5*s3/deep_arg->betao;
-			s4=s3*deep_arg->betao;
-			s1=-15*eq*s4;
-			s5=x1*x3+x2*x4;
-			s6=x2*x3+x1*x4;
-			s7=x2*x4-x1*x3;
-			se=s1*zn*s5;
-			si=s2*zn*(z11+z13);
-			sl=-zn*s3*(z1+z3-14-6*deep_arg->eosq);
-			sgh=s4*zn*(z31+z33-6);
-			sh=-zn*s2*(z21+z23);
-		
-			if (m->xqncl<5.2359877E-2)
-				sh=0;
-		    
-			m->ee2=2*s1*s6;
-			m->e3=2*s1*s7;
-			m->xi2=2*s2*z12;
-			m->xi3=2*s2*(z13-z11);
-			m->xl2=-2*s3*z2;
-			m->xl3=-2*s3*(z3-z1);
-			m->xl4=-2*s3*(-21-9*deep_arg->eosq)*ze;
-			m->xgh2=2*s4*z32;
-			m->xgh3=2*s4*(z33-z31);
-			m->xgh4=-18*s4*ze;
-			m->xh2=-2*s2*z22;
-			m->xh3=-2*s2*(z23-z21);
-
-			//Skip lunar terms?
-			if (m->lunarTermsDone) {
-				break;
-			}
-
-			/* Do lunar terms */
-			m->sse=se;
-			m->ssi=si;
-			m->ssl=sl;
-			m->ssh=sh/deep_arg->sinio;
-			m->ssg=sgh-deep_arg->cosio*m->ssh;
-			m->se2=m->ee2;
-			m->si2=m->xi2;
-			m->sl2=m->xl2;
-			m->sgh2=m->xgh2;
-			m->sh2=m->xh2;
-			m->se3=m->e3;
-			m->si3=m->xi3;
-			m->sl3=m->xl3;
-			m->sgh3=m->xgh3;
-			m->sh3=m->xh3;
-			m->sl4=m->xl4;
-			m->sgh4=m->xgh4;
-			zcosg=m->zcosgl;
-			zsing=m->zsingl;
-			zcosi=m->zcosil;
-			zsini=m->zsinil;
-			zcosh=m->zcoshl*cosq+m->zsinhl*sinq;
-			zsinh=sinq*m->zcoshl-cosq*m->zsinhl;
-			zn=znl;
-			cc=c1l;
-			ze=zel;
-			/* zmo=m->zmol; */
-			//Set lunarTermsDone flag:
-			m->lunarTermsDone = true;
-		}
-
-		m->sse=m->sse+se;
-		m->ssi=m->ssi+si;
-		m->ssl=m->ssl+sl;
-		m->ssg=m->ssg+sgh-deep_arg->cosio/deep_arg->sinio*sh;
-		m->ssh=m->ssh+sh/deep_arg->sinio;
-
-		/* Geopotential resonance initialization for 12 hour orbits */
-		m->resonanceFlag = 0;
-		m->synchronousFlag = 0;
-
-		if (!((m->xnq<0.0052359877) && (m->xnq>0.0034906585)))
-		{
-			if ((m->xnq<0.00826) || (m->xnq>0.00924))
-			    return;
-	
-			if (eq<0.5)
-			    return;
-	
-			m->resonanceFlag = 1;
-			eoc=eq*deep_arg->eosq;
-			g201=-0.306-(eq-0.64)*0.440;
-		
-			if (eq<=0.65)
-			{
-				g211=3.616-13.247*eq+16.290*deep_arg->eosq;
-				g310=-19.302+117.390*eq-228.419*deep_arg->eosq+156.591*eoc;
-				g322=-18.9068+109.7927*eq-214.6334*deep_arg->eosq+146.5816*eoc;
-				g410=-41.122+242.694*eq-471.094*deep_arg->eosq+313.953*eoc;
-				g422=-146.407+841.880*eq-1629.014*deep_arg->eosq+1083.435 * eoc;
-				g520=-532.114+3017.977*eq-5740*deep_arg->eosq+3708.276*eoc;
-			}
-		
-			else
-			{
-				g211=-72.099+331.819*eq-508.738*deep_arg->eosq+266.724*eoc;
-				g310=-346.844+1582.851*eq-2415.925*deep_arg->eosq+1246.113*eoc;
-				g322=-342.585+1554.908*eq-2366.899*deep_arg->eosq+1215.972*eoc;
-				g410=-1052.797+4758.686*eq-7193.992*deep_arg->eosq+3651.957*eoc;
-				g422=-3581.69+16178.11*eq-24462.77*deep_arg->eosq+12422.52*eoc;
-		      
-				if (eq<=0.715)
-					g520=1464.74-4664.75*eq+3763.64*deep_arg->eosq;
-			  
-				else
-					g520=-5149.66+29936.92*eq-54087.36*deep_arg->eosq+31324.56*eoc;
-			}
-
-			if (eq<0.7)
-			{
-				g533=-919.2277+4988.61*eq-9064.77*deep_arg->eosq+5542.21*eoc;
-				g521=-822.71072+4568.6173*eq-8491.4146*deep_arg->eosq+5337.524*eoc;
-				g532=-853.666+4690.25*eq-8624.77*deep_arg->eosq+5341.4*eoc;
-			}
-		
-			else
-			{
-				g533=-37995.78+161616.52*eq-229838.2*deep_arg->eosq+109377.94*eoc;
-				g521 =-51752.104+218913.95*eq-309468.16*deep_arg->eosq+146349.42*eoc;
-				g532 =-40023.88+170470.89*eq-242699.48*deep_arg->eosq+115605.82*eoc;
-			}
-
-			sini2=deep_arg->sinio*deep_arg->sinio;
-			f220=0.75*(1+2*deep_arg->cosio+deep_arg->theta2);
-			f221=1.5*sini2;
-			f321=1.875*deep_arg->sinio*(1-2*deep_arg->cosio-3*deep_arg->theta2);
-			f322=-1.875*deep_arg->sinio*(1+2*deep_arg->cosio-3*deep_arg->theta2);
-			f441=35*sini2*f220;
-			f442=39.3750*sini2*sini2;
-			f522=9.84375*deep_arg->sinio*(sini2*(1-2*deep_arg->cosio-5*deep_arg->theta2)+0.33333333*(-2+4*deep_arg->cosio+6*deep_arg->theta2));
-			f523=deep_arg->sinio*(4.92187512*sini2*(-2-4*deep_arg->cosio+10*deep_arg->theta2)+6.56250012*(1+2*deep_arg->cosio-3*deep_arg->theta2));
-			f542=29.53125*deep_arg->sinio*(2-8*deep_arg->cosio+deep_arg->theta2*(-12+8*deep_arg->cosio+10*deep_arg->theta2));
-			f543=29.53125*deep_arg->sinio*(-2-8*deep_arg->cosio+deep_arg->theta2*(12+8*deep_arg->cosio-10*deep_arg->theta2));
-			xno2=m->xnq*m->xnq;
-			ainv2=aqnv*aqnv;
-			temp1=3*xno2*ainv2;
-			temp=temp1*root22;
-			m->d2201=temp*f220*g201;
-			m->d2211=temp*f221*g211;
-			temp1=temp1*aqnv;
-			temp=temp1*root32;
-			m->d3210=temp*f321*g310;
-			m->d3222=temp*f322*g322;
-			temp1=temp1*aqnv;
-			temp=2*temp1*root44;
-			m->d4410=temp*f441*g410;
-			m->d4422=temp*f442*g422;
-			temp1=temp1*aqnv;
-			temp=temp1*root52;
-			m->d5220=temp*f522*g520;
-			m->d5232=temp*f523*g532;
-			temp=2*temp1*root54;
-			m->d5421=temp*f542*g521;
-			m->d5433=temp*f543*g533;
-			m->xlamo=xmao+xnodeo+xnodeo-m->thgr-m->thgr;
-			bfact=deep_arg->xmdot+deep_arg->xnodot+deep_arg->xnodot-thdt-thdt;
-			bfact=bfact+m->ssl+m->ssh+m->ssh;
-		}
-	
-		else
-		{
-			m->resonanceFlag = 1;
-			m->synchronousFlag = 1;
-	
-			/* Synchronous resonance terms initialization */
-			g200=1+deep_arg->eosq*(-2.5+0.8125*deep_arg->eosq);
-			g310=1+2*deep_arg->eosq;
-			g300=1+deep_arg->eosq*(-6+6.60937*deep_arg->eosq);
-			f220=0.75*(1+deep_arg->cosio)*(1+deep_arg->cosio);
-			f311=0.9375*deep_arg->sinio*deep_arg->sinio*(1+3*deep_arg->cosio)-0.75*(1+deep_arg->cosio);
-			f330=1+deep_arg->cosio;
-			f330=1.875*f330*f330*f330;
-			m->del1=3*m->xnq*m->xnq*aqnv*aqnv;
-			m->del2=2*m->del1*f220*g200*q22;
-			m->del3=3*m->del1*f330*g300*q33*aqnv;
-			m->del1=m->del1*f311*g310*q31*aqnv;
-			m->fasx2=0.13130908;
-			m->fasx4=2.8843198;
-			m->fasx6=0.37448087;
-			m->xlamo=xmao+xnodeo+omegao-m->thgr;
-			bfact=deep_arg->xmdot+xpidot-thdt;
-			bfact=bfact+m->ssl+m->ssg+m->ssh;
-		}
-
-		m->xfact=bfact-m->xnq;
-
-		/* Initialize integrator */
-		m->xli=m->xlamo;
-		m->xni=m->xnq;
-		m->atime=0;
-		m->stepp=720;
-		m->stepn=-720;
-		m->step2=259200;
-
-		return;
 
 		case DPSecular:  /* Entrance for deep space secular effects */
 
@@ -607,14 +621,14 @@ void sdp4_deep(struct _sdp4 *m, int ientry, const predict_orbital_elements_t * t
 		deep_arg->xnode=deep_arg->xnode+m->ssh*deep_arg->t;
 		deep_arg->em=eo+m->sse*deep_arg->t;
 		deep_arg->xinc=xincl+m->ssi*deep_arg->t;
-	  
+
 		if (deep_arg->xinc<0)
 		{
 			deep_arg->xinc=-deep_arg->xinc;
 			deep_arg->xnode=deep_arg->xnode+pi;
 			deep_arg->omgadf=deep_arg->omgadf-pi;
 		}
-	
+
 		if (!m->resonanceFlag) {
 			return;
 		}
@@ -645,7 +659,7 @@ void sdp4_deep(struct _sdp4 *m, int ientry, const predict_orbital_elements_t * t
 						delt=m->stepn;
 				}
 			}
-	    
+
 			do
 			{
 				if (fabs(deep_arg->t-m->atime)>=m->stepp)
@@ -653,7 +667,7 @@ void sdp4_deep(struct _sdp4 *m, int ientry, const predict_orbital_elements_t * t
 					m->loopFlag = 1;
 					m->epochRestartFlag = 0;
 				}
-		
+
 				else
 				{
 					ft=deep_arg->t-m->atime;
@@ -676,7 +690,7 @@ void sdp4_deep(struct _sdp4 *m, int ientry, const predict_orbital_elements_t * t
 					xndot=m->del1*sin(m->xli-m->fasx2)+m->del2*sin(2*(m->xli-m->fasx4))+m->del3*sin(3*(m->xli-m->fasx6));
 					xnddt=m->del1*cos(m->xli-m->fasx2)+2*m->del2*cos(2*(m->xli-m->fasx4))+3*m->del3*cos(3*(m->xli-m->fasx6));
 				}
-		
+
 				else
 				{
 					xomi=m->omegaq+deep_arg->omgdot*m->atime;
@@ -755,7 +769,7 @@ void sdp4_deep(struct _sdp4 *m, int ientry, const predict_orbital_elements_t * t
 			deep_arg->xnode=deep_arg->xnode+ph;
 			deep_arg->xll=deep_arg->xll+m->pl;
 		}
-	
+
 		else
 		{
 			/* Apply periodics with Lyddane modification */
@@ -776,7 +790,7 @@ void sdp4_deep(struct _sdp4 *m, int ientry, const predict_orbital_elements_t * t
 
 			/* This is a patch to Lyddane modification */
 			/* suggested by Rob Matson. */
-		
+
 			if (fabs(xnoh-deep_arg->xnode)>pi)
 			{
 			      if (deep_arg->xnode<xnoh)

--- a/src/sdp4.h
+++ b/src/sdp4.h
@@ -10,24 +10,42 @@ typedef struct	{
 		   	   /* Used by dpinit part of Deep() */
 		   double  eosq, sinio, cosio, betao, aodp, theta2,
 			   sing, cosg, betao2, xmdot, omgdot, xnodot, xnodp;
-	   
+
 			   /* Used by dpsec and dpper parts of Deep() */
 		   double  xll, omgadf, xnode, em, xinc, xn, t;
-    
+
 		 	   /* Used by thetg and Deep() */
 		   double  ds50;
 		}  deep_arg_t;
 
 /**
+ * Parameters for deep space perturbations.
+ **/
+typedef struct {
+	/* Used by dpinit part of Deep() */
+	double  eosq, sinio, cosio, betao, aodp, theta2,
+	sing, cosg, betao2, xmdot, omgdot, xnodot, xnodp;
+} deep_arg_fixed_t;
+
+/**
+ * Output from deep space perturbations.
+ **/
+typedef struct {
+	/* Used by dpsec and dpper parts of Deep() */
+	double  xll, omgadf, xnode, em, xinc, xn, t;
+
+	/* Used by thetg and Deep() */
+	double  ds50;
+} deep_arg_dynamic_t;
+
+/**
  * Parameters relevant for SDP4 (simplified deep space perturbations) orbital model.
  **/
 struct _sdp4 {
-	
+
 	//Phase?
 	double phase;
 
-	///Have the SDP4 function been initialized?
-	int initialized;
 	///Lunar terms done?
 	int lunarTermsDone;
 	///Resonance flag:
@@ -39,12 +57,12 @@ struct _sdp4 {
 	///Epoch restart flag:
 	int epochRestartFlag;
 
-	
+
 	///Static variables from SDP4():
 	double x3thm1, c1, x1mth2, c4, xnodcf, t2cof, xlcof,
 	aycof, x7thm1;
 	deep_arg_t deep_arg;
-	
+
 	///Static variables from Deep():
 	double thgr, xnq, xqncl, omegaq, zmol, zmos, savtsn, ee2, e3,
 	xi2, xl2, xl3, xl4, xgh2, xgh3, xgh4, xh2, xh3, sse, ssi, ssg, xi3,
@@ -59,14 +77,15 @@ struct _sdp4 {
 };
 
 /**
- * Initialize SDP4 model parameters. 
+ * Initialize SDP4 model parameters.
  *
+ * \param orbital_elements Orbital elements
  * \param m Struct to initialize
  **/
-void sdp4_init(struct _sdp4 *m);
+void sdp4_init(const predict_orbital_elements_t *orbital_elements, struct _sdp4 *m);
 
-/** 
- * Predict ECI position and velocity of deep-space orbit (period > 225 minutes) according to SDP4 model and the given orbital parameters. 
+/**
+ * Predict ECI position and velocity of deep-space orbit (period > 225 minutes) according to SDP4 model and the given orbital parameters.
  *
  * \param m SDP4 model parameters
  * \param tsince Time since epoch of TLE in minutes

--- a/src/sdp4.h
+++ b/src/sdp4.h
@@ -70,6 +70,16 @@ struct _sdp4 {
 	del2, del3, fasx2, fasx4, fasx6, xlamo, xfact, stepp,
 	stepn, step2, preep, d2201, d2211,
 	zsingl, zcosgl, zsinhl, zcoshl, zsinil, zcosil;
+
+	//converted fields from predict_orbital_elements_t.
+	double xnodeo;
+	double omegao;
+	double xmo;
+	double xincl;
+	double eo;
+	double xno;
+	double bstar;
+	double epoch;
 };
 
 /**
@@ -90,7 +100,7 @@ void sdp4_init(const predict_orbital_elements_t *orbital_elements, struct _sdp4 
  * \param vel Output velocity in m/s
  * \copyright GPLv2+
  **/
-void sdp4_predict(const struct _sdp4 *m, double tsince, const predict_orbital_elements_t * orbital_elements, struct model_output *output);
+void sdp4_predict(const struct _sdp4 *m, double tsince, struct model_output *output);
 
 /**
  * Deep space perturbations. Original Deep() function.
@@ -101,7 +111,7 @@ void sdp4_predict(const struct _sdp4 *m, double tsince, const predict_orbital_el
  * \param deep_arg Deep perturbation parameters
  * \copyright GPLv2+
  **/
-void sdp4_deep(const struct _sdp4 *m, int ientry, const predict_orbital_elements_t * tle, const deep_arg_fixed_t * deep_arg, deep_arg_dynamic_t *deep_dyn);
+void sdp4_deep(const struct _sdp4 *m, int ientry, const deep_arg_fixed_t * deep_arg, deep_arg_dynamic_t *deep_dyn);
 
 
 #endif // ifndef _SDP4_H_

--- a/src/sdp4.h
+++ b/src/sdp4.h
@@ -11,9 +11,6 @@ typedef struct	{
 		   double  eosq, sinio, cosio, betao, aodp, theta2,
 			   sing, cosg, betao2, xmdot, omgdot, xnodot, xnodp;
 
-			   /* Used by dpsec and dpper parts of Deep() */
-		   double  xll, omgadf, xnode, em, xinc, xn, t;
-
 		 	   /* Used by thetg and Deep() */
 		   double  ds50;
 
@@ -32,6 +29,7 @@ typedef struct {
  * Output from deep space perturbations.
  **/
 typedef struct {
+	/* Moved from deep_arg_t. */
 	/* Used by dpsec and dpper parts of Deep() */
 	double  xll, omgadf, xnode, em, xinc, xn, t;
 
@@ -78,6 +76,8 @@ struct _sdp4 {
 	zsingl, zcosgl, zsinhl, zcoshl, zsinil, zcosil;
 	//Variables that are used locally in SDP4(), but also are used to calculate squint angle elsewhere
 	double xnodek, xinck;
+
+	deep_arg_dynamic_t deep_dyn;
 };
 
 /**
@@ -109,7 +109,7 @@ void sdp4_predict(struct _sdp4 *m, double tsince, const predict_orbital_elements
  * \param deep_arg Deep perturbation parameters
  * \copyright GPLv2+
  **/
-void sdp4_deep(const struct _sdp4 *m, int ientry, const predict_orbital_elements_t * tle, deep_arg_t * deep_arg, deep_arg_dynamic_t *deep_dyn);
+void sdp4_deep(const struct _sdp4 *m, int ientry, const predict_orbital_elements_t * tle, const deep_arg_t * deep_arg, deep_arg_dynamic_t *deep_dyn);
 
 
 #endif // ifndef _SDP4_H_

--- a/src/sdp4.h
+++ b/src/sdp4.h
@@ -75,7 +75,7 @@ void sdp4_init(struct _sdp4 *m);
  * \param vel Output velocity in m/s
  * \copyright GPLv2+
  **/
-void sdp4_predict(struct _sdp4 *m, double tsince, predict_orbital_elements_t * orbital_elements, double pos[3], double vel[3]);
+void sdp4_predict(struct _sdp4 *m, double tsince, const predict_orbital_elements_t * orbital_elements, double pos[3], double vel[3]);
 
 /**
  * Deep space perturbations. Original Deep() function.
@@ -86,7 +86,7 @@ void sdp4_predict(struct _sdp4 *m, double tsince, predict_orbital_elements_t * o
  * \param deep_arg Deep perturbation parameters
  * \copyright GPLv2+
  **/
-void sdp4_deep(struct _sdp4 *m, int ientry, predict_orbital_elements_t * orbital_elements, deep_arg_t * deep_arg);
+void sdp4_deep(struct _sdp4 *m, int ientry, const predict_orbital_elements_t * orbital_elements, deep_arg_t * deep_arg);
 
 
 #endif // ifndef _SDP4_H_

--- a/src/sdp4.h
+++ b/src/sdp4.h
@@ -16,6 +16,7 @@ typedef struct	{
 
 		 	   /* Used by thetg and Deep() */
 		   double  ds50;
+
 		}  deep_arg_t;
 
 /**
@@ -36,7 +37,15 @@ typedef struct {
 
 	/* Used by thetg and Deep() */
 	double  ds50;
+
+	/* Previously a part of _sdp4, moved here. */
+	double pl, pinc, pe, sh1, sghl, shs, savtsn, atime, xni, xli, sghs;
+	///Do loop flag:
+	int loopFlag;
+	///Epoch restart flag:
+	int epochRestartFlag;
 } deep_arg_dynamic_t;
+
 
 /**
  * Parameters relevant for SDP4 (simplified deep space perturbations) orbital model.
@@ -52,10 +61,6 @@ struct _sdp4 {
 	int resonanceFlag;
 	///Synchronous flag:
 	int synchronousFlag;
-	///Do loop flag:
-	int loopFlag;
-	///Epoch restart flag:
-	int epochRestartFlag;
 
 
 	///Static variables from SDP4():
@@ -64,14 +69,13 @@ struct _sdp4 {
 	deep_arg_t deep_arg;
 
 	///Static variables from Deep():
-	double thgr, xnq, xqncl, omegaq, zmol, zmos, savtsn, ee2, e3,
+	double thgr, xnq, xqncl, omegaq, zmol, zmos, ee2, e3,
 	xi2, xl2, xl3, xl4, xgh2, xgh3, xgh4, xh2, xh3, sse, ssi, ssg, xi3,
 	se2, si2, sl2, sgh2, sh2, se3, si3, sl3, sgh3, sh3, sl4, sgh4, ssl,
 	ssh, d3210, d3222, d4410, d4422, d5220, d5232, d5421, d5433, del1,
-	del2, del3, fasx2, fasx4, fasx6, xlamo, xfact, xni, atime, stepp,
-	stepn, step2, preep, pl, sghs, xli, d2201, d2211, sghl, sh1, pinc,
-	pe, shs, zsingl, zcosgl, zsinhl, zcoshl, zsinil, zcosil;
-
+	del2, del3, fasx2, fasx4, fasx6, xlamo, xfact, stepp,
+	stepn, step2, preep, d2201, d2211,
+	zsingl, zcosgl, zsinhl, zcoshl, zsinil, zcosil;
 	//Variables that are used locally in SDP4(), but also are used to calculate squint angle elsewhere
 	double xnodek, xinck;
 };
@@ -105,7 +109,7 @@ void sdp4_predict(struct _sdp4 *m, double tsince, const predict_orbital_elements
  * \param deep_arg Deep perturbation parameters
  * \copyright GPLv2+
  **/
-void sdp4_deep(struct _sdp4 *m, int ientry, const predict_orbital_elements_t * orbital_elements, deep_arg_t * deep_arg);
+void sdp4_deep(const struct _sdp4 *m, int ientry, const predict_orbital_elements_t * tle, deep_arg_t * deep_arg, deep_arg_dynamic_t *deep_dyn);
 
 
 #endif // ifndef _SDP4_H_

--- a/src/sdp4.h
+++ b/src/sdp4.h
@@ -95,9 +95,7 @@ void sdp4_init(const predict_orbital_elements_t *orbital_elements, struct _sdp4 
  *
  * \param m SDP4 model parameters
  * \param tsince Time since epoch of TLE in minutes
- * \param orbital_elements Orbital parameters
- * \param pos Output ECI position in meters
- * \param vel Output velocity in m/s
+ * \param output Modeled output parameters
  * \copyright GPLv2+
  **/
 void sdp4_predict(const struct _sdp4 *m, double tsince, struct model_output *output);
@@ -106,9 +104,9 @@ void sdp4_predict(const struct _sdp4 *m, double tsince, struct model_output *out
  * Deep space perturbations. Original Deep() function.
  *
  * \param m SDP4 model parameters
- * \param ientry Behavior flag. 0: Deep space initialization. 1: Deep space secular effects. 2: lunar-solar periodics
- * \param orbital_elements Orbital parameters
- * \param deep_arg Deep perturbation parameters
+ * \param ientry Behavior flag. 1: Deep space secular effects. 2: lunar-solar periodics
+ * \param deep_arg Fixed deep perturbation parameters
+ * \param deep_dyn Output of deep space perturbations
  * \copyright GPLv2+
  **/
 void sdp4_deep(const struct _sdp4 *m, int ientry, const deep_arg_fixed_t * deep_arg, deep_arg_dynamic_t *deep_dyn);

--- a/src/sdp4.h
+++ b/src/sdp4.h
@@ -3,27 +3,29 @@
 
 #include <predict/predict.h>
 
+struct model_output {
+	double xinck; //inclination?
+	double omgadf; //argument of perigee?
+	double xnodek; //RAAN?
+
+	double pos[3];
+	double vel[3];
+
+	double phase;
+};
+
+
 /**
- * Parameters for deep space perturbations?
+ * Parameters for deep space perturbations
  **/
 typedef struct	{
-		   	   /* Used by dpinit part of Deep() */
-		   double  eosq, sinio, cosio, betao, aodp, theta2,
-			   sing, cosg, betao2, xmdot, omgdot, xnodot, xnodp;
-
-		 	   /* Used by thetg and Deep() */
-		   double  ds50;
-
-		}  deep_arg_t;
-
-/**
- * Parameters for deep space perturbations.
- **/
-typedef struct {
 	/* Used by dpinit part of Deep() */
 	double  eosq, sinio, cosio, betao, aodp, theta2,
 	sing, cosg, betao2, xmdot, omgdot, xnodot, xnodp;
-} deep_arg_fixed_t;
+
+	/* Used by thetg and Deep() */
+	double  ds50;
+}  deep_arg_fixed_t;
 
 /**
  * Output from deep space perturbations.
@@ -32,9 +34,6 @@ typedef struct {
 	/* Moved from deep_arg_t. */
 	/* Used by dpsec and dpper parts of Deep() */
 	double  xll, omgadf, xnode, em, xinc, xn, t;
-
-	/* Used by thetg and Deep() */
-	double  ds50;
 
 	/* Previously a part of _sdp4, moved here. */
 	double pl, pinc, pe, sh1, sghl, shs, savtsn, atime, xni, xli, sghs;
@@ -50,9 +49,6 @@ typedef struct {
  **/
 struct _sdp4 {
 
-	//Phase?
-	double phase;
-
 	///Lunar terms done?
 	int lunarTermsDone;
 	///Resonance flag:
@@ -64,7 +60,7 @@ struct _sdp4 {
 	///Static variables from SDP4():
 	double x3thm1, c1, x1mth2, c4, xnodcf, t2cof, xlcof,
 	aycof, x7thm1;
-	deep_arg_t deep_arg;
+	deep_arg_fixed_t deep_arg;
 
 	///Static variables from Deep():
 	double thgr, xnq, xqncl, omegaq, zmol, zmos, ee2, e3,
@@ -74,10 +70,6 @@ struct _sdp4 {
 	del2, del3, fasx2, fasx4, fasx6, xlamo, xfact, stepp,
 	stepn, step2, preep, d2201, d2211,
 	zsingl, zcosgl, zsinhl, zcoshl, zsinil, zcosil;
-	//Variables that are used locally in SDP4(), but also are used to calculate squint angle elsewhere
-	double xnodek, xinck;
-
-	deep_arg_dynamic_t deep_dyn;
 };
 
 /**
@@ -98,7 +90,7 @@ void sdp4_init(const predict_orbital_elements_t *orbital_elements, struct _sdp4 
  * \param vel Output velocity in m/s
  * \copyright GPLv2+
  **/
-void sdp4_predict(struct _sdp4 *m, double tsince, const predict_orbital_elements_t * orbital_elements, double pos[3], double vel[3]);
+void sdp4_predict(const struct _sdp4 *m, double tsince, const predict_orbital_elements_t * orbital_elements, struct model_output *output);
 
 /**
  * Deep space perturbations. Original Deep() function.
@@ -109,7 +101,7 @@ void sdp4_predict(struct _sdp4 *m, double tsince, const predict_orbital_elements
  * \param deep_arg Deep perturbation parameters
  * \copyright GPLv2+
  **/
-void sdp4_deep(const struct _sdp4 *m, int ientry, const predict_orbital_elements_t * tle, const deep_arg_t * deep_arg, deep_arg_dynamic_t *deep_dyn);
+void sdp4_deep(const struct _sdp4 *m, int ientry, const predict_orbital_elements_t * tle, const deep_arg_fixed_t * deep_arg, deep_arg_dynamic_t *deep_dyn);
 
 
 #endif // ifndef _SDP4_H_

--- a/src/sgp4.c
+++ b/src/sgp4.c
@@ -9,7 +9,7 @@ void sgp4_init(struct _sgp4 *m)
 	m->simpleFlag = 0;
 }
 
-void sgp4_predict(struct _sgp4 *m, double tsince, predict_orbital_elements_t *orbital_elements, double pos[3], double vel[3])
+void sgp4_predict(struct _sgp4 *m, double tsince, const predict_orbital_elements_t *orbital_elements, double pos[3], double vel[3])
 {
 	//Calculate old TLE field values as used in the original sgp4
 	double temp_tle = twopi/xmnpda/xmnpda;

--- a/src/sgp4.c
+++ b/src/sgp4.c
@@ -3,149 +3,144 @@
 #include "defs.h"
 #include "unsorted.h"
 
-void sgp4_init(struct _sgp4 *m)
+void sgp4_init(const predict_orbital_elements_t *orbital_elements, struct _sgp4 *m)
 {
-	m->initialized = 0;
 	m->simpleFlag = 0;
-}
 
-void sgp4_predict(struct _sgp4 *m, double tsince, const predict_orbital_elements_t *orbital_elements, double pos[3], double vel[3])
-{
 	//Calculate old TLE field values as used in the original sgp4
 	double temp_tle = twopi/xmnpda/xmnpda;
-	double bstar = orbital_elements->bstar_drag_term / ae;
-	double xincl = orbital_elements->inclination * M_PI / 180.0;
-	double xnodeo = orbital_elements->right_ascension * M_PI / 180.0;
-	double eo = orbital_elements->eccentricity;
-	double omegao = orbital_elements->argument_of_perigee * M_PI / 180.0;
-	double xmo = orbital_elements->mean_anomaly * M_PI / 180.0;
-	double xno = orbital_elements->mean_motion*temp_tle*xmnpda;
+	m->bstar = orbital_elements->bstar_drag_term / ae;
+	m->xincl = orbital_elements->inclination * M_PI / 180.0;
+	m->xnodeo = orbital_elements->right_ascension * M_PI / 180.0;
+	m->eo = orbital_elements->eccentricity;
+	m->omegao = orbital_elements->argument_of_perigee * M_PI / 180.0;
+	m->xmo = orbital_elements->mean_anomaly * M_PI / 180.0;
+	m->xno = orbital_elements->mean_motion*temp_tle*xmnpda;
 
+	double 	x1m5th, xhdot1,
+	a1, a3ovk2, ao,
+	betao, betao2, c1sq, c2, c3, coef, coef1, del1, delo, eeta, eosq,
+	etasq, perigee, pinvsq, psisq, qoms24, s4, temp, temp1, temp2,
+	temp3, theta2, theta4, tsi;
+
+	/* Recover original mean motion (m->xnodp) and   */
+	/* semimajor axis (m->aodp) from input elements. */
+
+	a1=pow(xke/m->xno,tothrd);
+	m->cosio=cos(m->xincl);
+	theta2=m->cosio*m->cosio;
+	m->x3thm1=3*theta2-1.0;
+	eosq=m->eo*m->eo;
+	betao2=1.0-eosq;
+	betao=sqrt(betao2);
+	del1=1.5*ck2*m->x3thm1/(a1*a1*betao*betao2);
+	ao=a1*(1.0-del1*(0.5*tothrd+del1*(1.0+134.0/81.0*del1)));
+	delo=1.5*ck2*m->x3thm1/(ao*ao*betao*betao2);
+	m->xnodp=m->xno/(1.0+delo);
+	m->aodp=ao/(1.0-delo);
+
+	/* For perigee less than 220 kilometers, the "simple"     */
+	/* flag is set and the equations are truncated to linear  */
+	/* variation in sqrt a and quadratic variation in mean    */
+	/* anomaly.  Also, the c3 term, the delta omega term, and */
+	/* the delta m term are dropped.                          */
+
+	if ((m->aodp*(1-m->eo)/ae)<(220/xkmper+ae))
+		m->simpleFlag = true;
+	else
+		m->simpleFlag = false;
+
+	/* For perigees below 156 km, the      */
+	/* values of s and qoms2t are altered. */
+
+	s4=s;
+	qoms24=qoms2t;
+	perigee=(m->aodp*(1-m->eo)-ae)*xkmper;
+
+	if (perigee<156.0)
+	{
+		if (perigee<=98.0)
+		    s4=20;
+		else
+		 s4=perigee-78.0;
+
+		qoms24=pow((120-s4)*ae/xkmper,4);
+		s4=s4/xkmper+ae;
+	}
+
+	pinvsq=1/(m->aodp*m->aodp*betao2*betao2);
+	tsi=1/(m->aodp-s4);
+	m->eta=m->aodp*m->eo*tsi;
+	etasq=m->eta*m->eta;
+	eeta=m->eo*m->eta;
+	psisq=fabs(1-etasq);
+	coef=qoms24*pow(tsi,4);
+	coef1=coef/pow(psisq,3.5);
+	c2=coef1*m->xnodp*(m->aodp*(1+1.5*etasq+eeta*(4+etasq))+0.75*ck2*tsi/psisq*m->x3thm1*(8+3*etasq*(8+etasq)));
+	m->c1=m->bstar*c2;
+	m->sinio=sin(m->xincl);
+	a3ovk2=-xj3/ck2*pow(ae,3);
+	c3=coef*tsi*a3ovk2*m->xnodp*ae*m->sinio/m->eo;
+	m->x1mth2=1-theta2;
+
+	m->c4=2*m->xnodp*coef1*m->aodp*betao2*(m->eta*(2+0.5*etasq)+m->eo*(0.5+2*etasq)-2*ck2*tsi/(m->aodp*psisq)*(-3*m->x3thm1*(1-2*eeta+etasq*(1.5-0.5*eeta))+0.75*m->x1mth2*(2*etasq-eeta*(1+etasq))*cos(2*m->omegao)));
+	m->c5=2*coef1*m->aodp*betao2*(1+2.75*(etasq+eeta)+eeta*etasq);
+
+	theta4=theta2*theta2;
+	temp1=3*ck2*pinvsq*m->xnodp;
+	temp2=temp1*ck2*pinvsq;
+	temp3=1.25*ck4*pinvsq*pinvsq*m->xnodp;
+	m->xmdot=m->xnodp+0.5*temp1*betao*m->x3thm1+0.0625*temp2*betao*(13-78*theta2+137*theta4);
+	x1m5th=1-5*theta2;
+	m->omgdot=-0.5*temp1*x1m5th+0.0625*temp2*(7-114*theta2+395*theta4)+temp3*(3-36*theta2+49*theta4);
+	xhdot1=-temp1*m->cosio;
+	m->xnodot=xhdot1+(0.5*temp2*(4-19*theta2)+2*temp3*(3-7*theta2))*m->cosio;
+	m->omgcof=m->bstar*c3*cos(m->omegao);
+	m->xmcof=-tothrd*coef*m->bstar*ae/eeta;
+	m->xnodcf=3.5*betao2*xhdot1*m->c1;
+	m->t2cof=1.5*m->c1;
+	m->xlcof=0.125*a3ovk2*m->sinio*(3+5*m->cosio)/(1+m->cosio);
+	m->aycof=0.25*a3ovk2*m->sinio;
+	m->delmo=pow(1+m->eta*cos(m->xmo),3);
+	m->sinmo=sin(m->xmo);
+	m->x7thm1=7*theta2-1;
+
+	if (!m->simpleFlag) {
+		c1sq=m->c1*m->c1;
+		m->d2=4*m->aodp*tsi*c1sq;
+		temp=m->d2*tsi*m->c1/3;
+		m->d3=(17*m->aodp+s4)*temp;
+		m->d4=0.5*temp*m->aodp*tsi*(221*m->aodp+31*s4)*m->c1;
+		m->t3cof=m->d2+2*c1sq;
+		m->t4cof=0.25*(3*m->d3+m->c1*(12*m->d2+10*c1sq));
+		m->t5cof=0.2*(3*m->d4+12*m->c1*m->d3+6*m->d2*m->d2+15*c1sq*(2*m->d2+c1sq));
+	}
+}
+
+void sgp4_predict(const struct _sgp4 *m, double tsince, double pos[3], double vel[3], double *phase)
+{
 	double cosuk, sinuk, rfdotk, vx, vy, vz, ux, uy, uz, xmy, xmx, cosnok,
 	sinnok, cosik, sinik, rdotk, xinck, xnodek, uk, rk, cos2u, sin2u,
 	u, sinu, cosu, betal, rfdot, rdot, r, pl, elsq, esine, ecose, epw,
-	cosepw, x1m5th, xhdot1, tfour, sinepw, capu, ayn, xlt, aynl, xll,
+	cosepw, tfour, sinepw, capu, ayn, xlt, aynl, xll,
 	axn, xn, beta, xl, e, a, tcube, delm, delomg, templ, tempe, tempa,
-	xnode, tsq, xmp, omega, xnoddf, omgadf, xmdf, a1, a3ovk2, ao,
-	betao, betao2, c1sq, c2, c3, coef, coef1, del1, delo, eeta, eosq,
-	etasq, perigee, pinvsq, psisq, qoms24, s4, temp, temp1, temp2,
-	temp3, temp4, temp5, temp6, theta2, theta4, tsi;
+	xnode, tsq, xmp, omega, xnoddf, omgadf, xmdf, temp, temp1, temp2,
+	temp3, temp4, temp5, temp6;
 
 	int i;
 
-	/* Initialization */
-
-	if (!m->initialized) {
-
-		//Set initialized flag:
-		m->initialized = true;
-
-		/* Recover original mean motion (m->xnodp) and   */
-		/* semimajor axis (m->aodp) from input elements. */
-
-		a1=pow(xke/xno,tothrd);
-		m->cosio=cos(xincl);
-		theta2=m->cosio*m->cosio;
-		m->x3thm1=3*theta2-1.0;
-		eosq=eo*eo;
-		betao2=1.0-eosq;
-		betao=sqrt(betao2);
-		del1=1.5*ck2*m->x3thm1/(a1*a1*betao*betao2);
-		ao=a1*(1.0-del1*(0.5*tothrd+del1*(1.0+134.0/81.0*del1)));
-		delo=1.5*ck2*m->x3thm1/(ao*ao*betao*betao2);
-		m->xnodp=xno/(1.0+delo);
-		m->aodp=ao/(1.0-delo);
-
-		/* For perigee less than 220 kilometers, the "simple"     */
-		/* flag is set and the equations are truncated to linear  */
-		/* variation in sqrt a and quadratic variation in mean    */
-		/* anomaly.  Also, the c3 term, the delta omega term, and */
-		/* the delta m term are dropped.                          */
-
-		if ((m->aodp*(1-eo)/ae)<(220/xkmper+ae))
-			m->simpleFlag = true;
-		else
-			m->simpleFlag = false;
-
-		/* For perigees below 156 km, the      */
-		/* values of s and qoms2t are altered. */
-
-		s4=s;
-		qoms24=qoms2t;
-		perigee=(m->aodp*(1-eo)-ae)*xkmper;
-
-		if (perigee<156.0)
-		{
-			if (perigee<=98.0)
-			    s4=20;
-			else
-		   	 s4=perigee-78.0;
-
-			qoms24=pow((120-s4)*ae/xkmper,4);
-			s4=s4/xkmper+ae;
-		}
-
-		pinvsq=1/(m->aodp*m->aodp*betao2*betao2);
-		tsi=1/(m->aodp-s4);
-		m->eta=m->aodp*eo*tsi;
-		etasq=m->eta*m->eta;
-		eeta=eo*m->eta;
-		psisq=fabs(1-etasq);
-		coef=qoms24*pow(tsi,4);
-		coef1=coef/pow(psisq,3.5);
-		c2=coef1*m->xnodp*(m->aodp*(1+1.5*etasq+eeta*(4+etasq))+0.75*ck2*tsi/psisq*m->x3thm1*(8+3*etasq*(8+etasq)));
-		m->c1=bstar*c2;
-		m->sinio=sin(xincl);
-		a3ovk2=-xj3/ck2*pow(ae,3);
-		c3=coef*tsi*a3ovk2*m->xnodp*ae*m->sinio/eo;
-		m->x1mth2=1-theta2;
-
-		m->c4=2*m->xnodp*coef1*m->aodp*betao2*(m->eta*(2+0.5*etasq)+eo*(0.5+2*etasq)-2*ck2*tsi/(m->aodp*psisq)*(-3*m->x3thm1*(1-2*eeta+etasq*(1.5-0.5*eeta))+0.75*m->x1mth2*(2*etasq-eeta*(1+etasq))*cos(2*omegao)));
-		m->c5=2*coef1*m->aodp*betao2*(1+2.75*(etasq+eeta)+eeta*etasq);
-
-		theta4=theta2*theta2;
-		temp1=3*ck2*pinvsq*m->xnodp;
-		temp2=temp1*ck2*pinvsq;
-		temp3=1.25*ck4*pinvsq*pinvsq*m->xnodp;
-		m->xmdot=m->xnodp+0.5*temp1*betao*m->x3thm1+0.0625*temp2*betao*(13-78*theta2+137*theta4);
-		x1m5th=1-5*theta2;
-		m->omgdot=-0.5*temp1*x1m5th+0.0625*temp2*(7-114*theta2+395*theta4)+temp3*(3-36*theta2+49*theta4);
-		xhdot1=-temp1*m->cosio;
-		m->xnodot=xhdot1+(0.5*temp2*(4-19*theta2)+2*temp3*(3-7*theta2))*m->cosio;
-		m->omgcof=bstar*c3*cos(omegao);
-		m->xmcof=-tothrd*coef*bstar*ae/eeta;
-		m->xnodcf=3.5*betao2*xhdot1*m->c1;
-		m->t2cof=1.5*m->c1;
-		m->xlcof=0.125*a3ovk2*m->sinio*(3+5*m->cosio)/(1+m->cosio);
-		m->aycof=0.25*a3ovk2*m->sinio;
-		m->delmo=pow(1+m->eta*cos(xmo),3);
-		m->sinmo=sin(xmo);
-		m->x7thm1=7*theta2-1;
-
-		if (!m->simpleFlag) {
-			c1sq=m->c1*m->c1;
-			m->d2=4*m->aodp*tsi*c1sq;
-			temp=m->d2*tsi*m->c1/3;
-			m->d3=(17*m->aodp+s4)*temp;
-			m->d4=0.5*temp*m->aodp*tsi*(221*m->aodp+31*s4)*m->c1;
-			m->t3cof=m->d2+2*c1sq;
-			m->t4cof=0.25*(3*m->d3+m->c1*(12*m->d2+10*c1sq));
-			m->t5cof=0.2*(3*m->d4+12*m->c1*m->d3+6*m->d2*m->d2+15*c1sq*(2*m->d2+c1sq));
-		}
-	}
-
 	/* Update for secular gravity and atmospheric drag. */
-	xmdf=xmo+m->xmdot*tsince;
-	omgadf=omegao+m->omgdot*tsince;
-	xnoddf=xnodeo+m->xnodot*tsince;
+	xmdf=m->xmo+m->xmdot*tsince;
+	omgadf=m->omegao+m->omgdot*tsince;
+	xnoddf=m->xnodeo+m->xnodot*tsince;
 	omega=omgadf;
 	xmp=xmdf;
 	tsq=tsince*tsince;
 	xnode=xnoddf+m->xnodcf*tsq;
 	tempa=1-m->c1*tsince;
-	tempe=bstar*m->c4*tsince;
+	tempe=m->bstar*m->c4*tsince;
 	templ=m->t2cof*tsq;
-    
+
 	if (!m->simpleFlag) {
 
 		delomg=m->omgcof*tsince;
@@ -156,12 +151,12 @@ void sgp4_predict(struct _sgp4 *m, double tsince, const predict_orbital_elements
 		tcube=tsq*tsince;
 		tfour=tsince*tcube;
 		tempa=tempa-m->d2*tsq-m->d3*tcube-m->d4*tfour;
-		tempe=tempe+bstar*m->c5*(sin(xmp)-m->sinmo);
+		tempe=tempe+m->bstar*m->c5*(sin(xmp)-m->sinmo);
 		templ=templ+m->t3cof*tcube+tfour*(m->t4cof+tsince*m->t5cof);
 	}
 
 	a=m->aodp*pow(tempa,2);
-	e=eo-tempe;
+	e=m->eo-tempe;
 	xl=xmp+omega+xnode+m->xnodp*templ;
 	beta=sqrt(1-e*e);
 	xn=xke/pow(a,1.5);
@@ -188,10 +183,10 @@ void sgp4_predict(struct _sgp4 *m, double tsince, const predict_orbital_elements
 		temp5=axn*cosepw;
 		temp6=ayn*sinepw;
 		epw=(capu-temp4+temp3-temp2)/(1-temp5-temp6)+temp2;
-	  
+
 		if (fabs(epw-temp2)<= e6a)
 			break;
-	      
+
 		temp2=epw;
 
 	} while (i++<10);
@@ -222,7 +217,7 @@ void sgp4_predict(struct _sgp4 *m, double tsince, const predict_orbital_elements
 	rk=r*(1-1.5*temp2*betal*m->x3thm1)+0.5*temp1*m->x1mth2*cos2u;
 	uk=u-0.25*temp2*m->x7thm1*sin2u;
 	xnodek=xnode+1.5*temp2*m->cosio*sin2u;
-	xinck=xincl+1.5*temp2*m->cosio*m->sinio*cos2u;
+	xinck=m->xincl+1.5*temp2*m->cosio*m->sinio*cos2u;
 	rdotk=rdot-xn*temp1*m->x1mth2*sin2u;
 	rfdotk=rfdot+xn*temp1*(m->x1mth2*cos2u+1.5*m->x3thm1);
 
@@ -251,11 +246,11 @@ void sgp4_predict(struct _sgp4 *m, double tsince, const predict_orbital_elements
 	vel[2] = rdotk*uz+rfdotk*vz;
 
 	/* Phase in radians */
-	m->phase=xlt-xnode-omgadf+twopi;
-    
-	if (m->phase<0.0)
-		m->phase+=twopi;
+	*phase=xlt-xnode-omgadf+twopi;
 
-	m->phase=FMod2p(m->phase);
+	if (*phase<0.0)
+		*phase+=twopi;
+
+	*phase=FMod2p(*phase);
 
 }

--- a/src/sgp4.c
+++ b/src/sgp4.c
@@ -117,7 +117,7 @@ void sgp4_init(const predict_orbital_elements_t *orbital_elements, struct _sgp4 
 	}
 }
 
-void sgp4_predict(const struct _sgp4 *m, double tsince, double pos[3], double vel[3], double *phase)
+void sgp4_predict(const struct _sgp4 *m, double tsince, struct model_output *output)
 {
 	double cosuk, sinuk, rfdotk, vx, vy, vz, ux, uy, uz, xmy, xmx, cosnok,
 	sinnok, cosik, sinik, rdotk, xinck, xnodek, uk, rk, cos2u, sin2u,
@@ -238,19 +238,23 @@ void sgp4_predict(const struct _sgp4 *m, double tsince, double pos[3], double ve
 	vz=sinik*cosuk;
 
 	/* Position and velocity */
-	pos[0] = rk*ux;
-	pos[1] = rk*uy;
-	pos[2] = rk*uz;
-	vel[0] = rdotk*ux+rfdotk*vx;
-	vel[1] = rdotk*uy+rfdotk*vy;
-	vel[2] = rdotk*uz+rfdotk*vz;
+	output->pos[0] = rk*ux;
+	output->pos[1] = rk*uy;
+	output->pos[2] = rk*uz;
+	output->vel[0] = rdotk*ux+rfdotk*vx;
+	output->vel[1] = rdotk*uy+rfdotk*vy;
+	output->vel[2] = rdotk*uz+rfdotk*vz;
 
 	/* Phase in radians */
-	*phase=xlt-xnode-omgadf+twopi;
+	output->phase=xlt-xnode-omgadf+twopi;
 
-	if (*phase<0.0)
-		*phase+=twopi;
+	if (output->phase<0.0)
+		output->phase+=twopi;
 
-	*phase=FMod2p(*phase);
+	output->phase=FMod2p(output->phase);
+
+	output->xinck = xinck;
+	output->omgadf = omgadf;
+	output->xnodek = xnodek;
 
 }

--- a/src/sgp4.h
+++ b/src/sgp4.h
@@ -40,6 +40,6 @@ void sgp4_init(struct _sgp4 *m);
  * \param vel Output velocity in m/s
  * \copyright GPLv2+
  **/
-void sgp4_predict(struct _sgp4 *m, double tsince, predict_orbital_elements_t *orbital_elements, double pos[3], double vel[3]);
+void sgp4_predict(struct _sgp4 *m, double tsince, const predict_orbital_elements_t *orbital_elements, double pos[3], double vel[3]);
 
 #endif

--- a/src/sgp4.h
+++ b/src/sgp4.h
@@ -2,6 +2,7 @@
 #define SGP4_H_
 
 #include <predict/predict.h>
+#include "sdp4.h"
 
 /**
  * Parameters relevant for SGP4 (simplified general perturbations) orbital model.
@@ -43,6 +44,6 @@ void sgp4_init(const predict_orbital_elements_t *orbital_elements, struct _sgp4 
  * \param phase Output phase (mean anomaly)
  * \copyright GPLv2+
  **/
-void sgp4_predict(const struct _sgp4 *m, double tsince, double pos[3], double vel[3], double *phase);
+void sgp4_predict(const struct _sgp4 *m, double tsince, struct model_output *output);
 
 #endif

--- a/src/sgp4.h
+++ b/src/sgp4.h
@@ -8,19 +8,22 @@
  **/
 struct _sgp4 {
 	
-	///Phase?
-	double phase;
-	
-	///Initialized flag:
-	int initialized;
-	
 	///Simple flag
 	int simpleFlag;
 
-	///Static variables from original SGP4()
+	///Static variables from original SGP4() (time-independent, and might probably have physical meaningfulness)
 	double aodp, aycof, c1, c4, c5, cosio, d2, d3, d4, delmo,
 	omgcof, eta, omgdot, sinio, xnodp, sinmo, t2cof, t3cof, t4cof,
 	t5cof, x1mth2, x3thm1, x7thm1, xmcof, xmdot, xnodcf, xnodot, xlcof;
+
+	//tle fields copied (and converted) from predict_orbital_t. The fields above are TLE-dependent anyway, and interrelated with the values below.
+	double bstar;
+	double xincl;
+	double xnodeo;
+	double eo;
+	double omegao;
+	double xmo;
+	double xno;
 };
 
 /**
@@ -28,18 +31,18 @@ struct _sgp4 {
  *
  * \param m Struct to initialize
  **/
-void sgp4_init(struct _sgp4 *m);
+void sgp4_init(const predict_orbital_elements_t *orbital_elements, struct _sgp4 *m);
 
 /**
  * Predict ECI position and velocity of near-earth orbit (period < 225 minutes) according to SGP4 model and the given orbital parameters. 
  *
  * \param m SGP4 model parameters
  * \param tsince Time since epoch of TLE in minutes
- * \param orbital_elements Orbital parameters
  * \param pos Output ECI position in meters
  * \param vel Output velocity in m/s
+ * \param phase Output phase (mean anomaly)
  * \copyright GPLv2+
  **/
-void sgp4_predict(struct _sgp4 *m, double tsince, const predict_orbital_elements_t *orbital_elements, double pos[3], double vel[3]);
+void sgp4_predict(const struct _sgp4 *m, double tsince, double pos[3], double vel[3], double *phase);
 
 #endif

--- a/src/sgp4.h
+++ b/src/sgp4.h
@@ -30,7 +30,9 @@ struct _sgp4 {
 /**
  * Initialize SGP4 model parameters.  
  *
+ * \param orbital_elements Orbital elements
  * \param m Struct to initialize
+ * \copyright GPLv2+
  **/
 void sgp4_init(const predict_orbital_elements_t *orbital_elements, struct _sgp4 *m);
 
@@ -39,9 +41,7 @@ void sgp4_init(const predict_orbital_elements_t *orbital_elements, struct _sgp4 
  *
  * \param m SGP4 model parameters
  * \param tsince Time since epoch of TLE in minutes
- * \param pos Output ECI position in meters
- * \param vel Output velocity in m/s
- * \param phase Output phase (mean anomaly)
+ * \param output Output of model
  * \copyright GPLv2+
  **/
 void sgp4_predict(const struct _sgp4 *m, double tsince, struct model_output *output);

--- a/tests/aoslos-t.cpp
+++ b/tests/aoslos-t.cpp
@@ -48,7 +48,7 @@ int runtest(const char *filename)
 
 	// Create orbit object
 	predict_orbital_elements_t *orbital_elements = predict_parse_tle(tle);
-	predict_orbit_t orbit;
+	struct predict_orbit orbit;
 
 	// Create observer object
 	predict_observer_t *obs = predict_create_observer("test", testcase.latitude()*M_PI/180.0, testcase.longitude()*M_PI/180.0, testcase.altitude());

--- a/tests/aoslos-t.cpp
+++ b/tests/aoslos-t.cpp
@@ -47,8 +47,8 @@ int runtest(const char *filename)
 	testcase.getTLE(tle);
 
 	// Create orbit object
-	predict_orbital_elements_t orbital_elements = predict_parse_tle(tle);
-	predict_orbit_t *orbit = predict_create_orbit(orbital_elements);
+	predict_orbital_elements_t *orbital_elements = predict_parse_tle(tle);
+	predict_orbit_t *orbit = predict_create_orbit();
 	if (!orbit) {
 		fprintf(stderr, "Failed to initialize orbit from tle!");
 		return -1;
@@ -67,8 +67,8 @@ int runtest(const char *filename)
 	// Use first available time as start time for AOS/LOS finding
 	double start_time = testcase.data()[0][0];
 
-	predict_julian_date_t next_aos_time = predict_next_aos(obs, &orbital_elements, predict_to_julian(start_time));
-	predict_julian_date_t next_los_time = predict_next_los(obs, &orbital_elements, predict_to_julian(start_time)); //can be LOS of current pass, if satellite is in range
+	predict_julian_date_t next_aos_time = predict_next_aos(obs, orbital_elements, predict_to_julian(start_time));
+	predict_julian_date_t next_los_time = predict_next_los(obs, orbital_elements, predict_to_julian(start_time)); //can be LOS of current pass, if satellite is in range
 	
 	double time_diff = 1.0/(60.0*60.0*24.0); //1 second
 	predict_julian_date_t curr_time = predict_to_julian(start_time);
@@ -78,7 +78,7 @@ int runtest(const char *filename)
 	// Check times until the AOS
 	while (curr_time < next_aos_time) {
 		struct predict_observation orbit_obs;
-		predict_orbit(&orbital_elements, orbit, curr_time);
+		predict_orbit(orbital_elements, orbit, curr_time);
 		predict_observe_orbit(obs, orbit, &orbit_obs);
 
 		if ((next_los_time < next_aos_time) && (curr_time < next_los_time)) {
@@ -98,10 +98,10 @@ int runtest(const char *filename)
 	}
 
 	// Check times up till LOS
-	next_los_time = predict_next_los(obs, &orbital_elements, predict_to_julian(curr_time)); //recalculating within the pass in case LOS was for previous pass
+	next_los_time = predict_next_los(obs, orbital_elements, predict_to_julian(curr_time)); //recalculating within the pass in case LOS was for previous pass
 	while (curr_time < next_los_time) {
 		struct predict_observation orbit_obs;
-		predict_orbit(&orbital_elements, orbit, curr_time);
+		predict_orbit(orbital_elements, orbit, curr_time);
 		predict_observe_orbit(obs, orbit, &orbit_obs);
 
 		//satellite should be above the horizon

--- a/tests/aoslos-t.cpp
+++ b/tests/aoslos-t.cpp
@@ -48,11 +48,7 @@ int runtest(const char *filename)
 
 	// Create orbit object
 	predict_orbital_elements_t *orbital_elements = predict_parse_tle(tle);
-	predict_orbit_t *orbit = predict_create_orbit();
-	if (!orbit) {
-		fprintf(stderr, "Failed to initialize orbit from tle!");
-		return -1;
-	}
+	predict_orbit_t orbit;
 
 	// Create observer object
 	predict_observer_t *obs = predict_create_observer("test", testcase.latitude()*M_PI/180.0, testcase.longitude()*M_PI/180.0, testcase.altitude());
@@ -78,8 +74,8 @@ int runtest(const char *filename)
 	// Check times until the AOS
 	while (curr_time < next_aos_time) {
 		struct predict_observation orbit_obs;
-		predict_orbit(orbital_elements, orbit, curr_time);
-		predict_observe_orbit(obs, orbit, &orbit_obs);
+		predict_orbit(orbital_elements, &orbit, curr_time);
+		predict_observe_orbit(obs, &orbit, &orbit_obs);
 
 		if ((next_los_time < next_aos_time) && (curr_time < next_los_time)) {
 			//satellite should be above the horizon (satellite was in range at the start time)
@@ -101,8 +97,8 @@ int runtest(const char *filename)
 	next_los_time = predict_next_los(obs, orbital_elements, predict_to_julian(curr_time)); //recalculating within the pass in case LOS was for previous pass
 	while (curr_time < next_los_time) {
 		struct predict_observation orbit_obs;
-		predict_orbit(orbital_elements, orbit, curr_time);
-		predict_observe_orbit(obs, orbit, &orbit_obs);
+		predict_orbit(orbital_elements, &orbit, curr_time);
+		predict_observe_orbit(obs, &orbit, &orbit_obs);
 
 		//satellite should be above the horizon
 		if (orbit_obs.elevation*180/M_PI < -ELEVATION_THRESH) {

--- a/tests/orbit-t.cpp
+++ b/tests/orbit-t.cpp
@@ -49,17 +49,17 @@ int runtest(const char *filename)
 	testcase.getTLE(tle);
 
 	// Create orbit objects
-	predict_orbital_elements_t orbital_elements = predict_parse_tle(tle);
+	predict_orbital_elements_t *orbital_elements = predict_parse_tle(tle);
 
 	// Used in lower bound in value check
-	predict_orbit_t *orbit_lower = predict_create_orbit(orbital_elements);
+	predict_orbit_t *orbit_lower = predict_create_orbit();
 	if (!orbit_lower) {
 		fprintf(stderr, "Failed to initialize orbit from tle!");
 		return -1;
 	}
 
 	// Used in upper bound in value check
-	predict_orbit_t *orbit_upper = predict_create_orbit(orbital_elements);
+	predict_orbit_t *orbit_upper = predict_create_orbit();
 	if (!orbit_upper) {
 		fprintf(stderr, "Failed to initialize orbit from tle!");
 		return -1;
@@ -72,7 +72,7 @@ int runtest(const char *filename)
 		return -1;
 	}
 
-	bool check_squint_angle = testcase.containsValidAlonAlat() && (orbit_lower->ephemeris == EPHEMERIS_SDP4);
+	bool check_squint_angle = testcase.containsValidAlonAlat() && (orbital_elements->ephemeris == EPHEMERIS_SDP4);
 	
 	// Test
 	int retval = 0;
@@ -116,11 +116,11 @@ int runtest(const char *filename)
 		struct predict_observation orbit_obs_upper;
 
 		// Lower bound
-		predict_orbit(&orbital_elements, orbit_lower, predict_to_julian(time));
+		predict_orbit(orbital_elements, orbit_lower, predict_to_julian(time));
 		predict_observe_orbit(obs, orbit_lower, &orbit_obs_lower);
 
 		// Upper bound
-		predict_orbit(&orbital_elements, orbit_upper, predict_to_julian(time + DIFF));
+		predict_orbit(orbital_elements, orbit_upper, predict_to_julian(time + DIFF));
 		predict_observe_orbit(obs, orbit_upper, &orbit_obs_upper);
 
 		// Check values

--- a/tests/orbit-t.cpp
+++ b/tests/orbit-t.cpp
@@ -52,10 +52,10 @@ int runtest(const char *filename)
 	predict_orbital_elements_t *orbital_elements = predict_parse_tle(tle);
 
 	// Used in lower bound in value check
-	predict_orbit_t orbit_lower;
+	struct predict_orbit orbit_lower;
 
 	// Used in upper bound in value check
-	predict_orbit_t orbit_upper;
+	struct predict_orbit orbit_upper;
 
 	// Create observer object
 	predict_observer_t *obs = predict_create_observer("test", testcase.latitude()*M_PI/180.0, testcase.longitude()*M_PI/180.0, testcase.altitude());

--- a/tests/orbit-t.cpp
+++ b/tests/orbit-t.cpp
@@ -49,16 +49,17 @@ int runtest(const char *filename)
 	testcase.getTLE(tle);
 
 	// Create orbit objects
+	predict_orbital_elements_t orbital_elements = predict_parse_tle(tle);
 
 	// Used in lower bound in value check
-	predict_orbit_t *orbit_lower = predict_create_orbit(predict_parse_tle(tle));
+	predict_orbit_t *orbit_lower = predict_create_orbit(orbital_elements);
 	if (!orbit_lower) {
 		fprintf(stderr, "Failed to initialize orbit from tle!");
 		return -1;
 	}
 
 	// Used in upper bound in value check
-	predict_orbit_t *orbit_upper = predict_create_orbit(predict_parse_tle(tle));
+	predict_orbit_t *orbit_upper = predict_create_orbit(orbital_elements);
 	if (!orbit_upper) {
 		fprintf(stderr, "Failed to initialize orbit from tle!");
 		return -1;
@@ -115,11 +116,11 @@ int runtest(const char *filename)
 		struct predict_observation orbit_obs_upper;
 
 		// Lower bound
-		predict_orbit(orbit_lower, predict_to_julian(time));
+		predict_orbit(&orbital_elements, orbit_lower, predict_to_julian(time));
 		predict_observe_orbit(obs, orbit_lower, &orbit_obs_lower);
 
 		// Upper bound
-		predict_orbit(orbit_upper, predict_to_julian(time + DIFF));
+		predict_orbit(&orbital_elements, orbit_upper, predict_to_julian(time + DIFF));
 		predict_observe_orbit(obs, orbit_upper, &orbit_obs_upper);
 
 		// Check values


### PR DESCRIPTION
All fixed orbit parameters have been moved out of predict_orbit_t, and struct predict_orbit is now a pure container for calculated values. 
- Major rehaul of SGP4 and SDP4: Initializations are moved to separate functions, so that there is actual separation between which fields in the model are fixed, and which fields are changing. (SGP4 fields are always fixed, moving SDP4-fields can be contained within a small struct for obtaining output from sdp4_deep locally within sdp4_predict)
- The pointer containing the SGP4/SDP4 data is now time-independent and only dependent on the TLE itself, and will stay fixed after initialization. This has therefore been moved to the predict_orbital_elements_t struct. 
- Added inclination, argument of perigee and right ascension to predict_orbit_t. 
- Removed memory allocation for predict_orbit_t, renamed to struct predict_orbit in line with struct predict_observation. 
