### PR TITLE
fixing missing declaration in testcase_reader.cpp

### DIFF
--- a/tests/testcase_reader.cpp
+++ b/tests/testcase_reader.cpp
@@ -12,6 +12,8 @@
 #include <locale>
 #include <string.h>
 
+#include <cmath>
+
 using namespace std;
 
 TestCaseReader::TestCaseReader()


### PR DESCRIPTION
As discussed in #libpredict 
