### PR TITLE
Issue51 - Make basic example compile again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,21 @@ compiler:
   - gcc
   - clang
 
-script: mkdir -p build; cd build; cmake --version && cmake .. && make && make test
+before_script:
+        - export LIBPREDICT_INSTALL_PATH="$PWD/libpredict-install"
+        - mkdir -p $LIBPREDICT_INSTALL_PATH/lib
+        - mkdir -p build
+
+script:
+        - cd build; cmake --version
+        - cmake -D CMAKE_INSTALL_PREFIX=$LIBPREDICT_INSTALL_PATH ..
+        - make
+        - make test
+        - make install
+        - mkdir -p examples
+        - cd examples
+        - cmake -D CMAKE_C_FLAGS="-I $LIBPREDICT_INSTALL_PATH/include -L $LIBPREDICT_INSTALL_PATH/lib" ../../examples
+        - make
 
 notifications:
   irc:

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8)
+
+add_subdirectory(basic)
+add_subdirectory(setrise)

--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(basic-example C)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+
+add_executable(basic-example main.c)
+target_link_libraries(basic-example predict)

--- a/examples/basic/Makefile
+++ b/examples/basic/Makefile
@@ -1,2 +1,0 @@
-all:
-	gcc main.c -Wall -lpredict -lm -o basic

--- a/examples/basic/README
+++ b/examples/basic/README
@@ -3,5 +3,5 @@ of the International Space Station (latitude, longitude and altitude)
 from a hard coded two-line element. The application will continue
 printing the updated position until it's aborted.
 
-The provided Makefile assumes libpredict and its development files are
+The provided CMakeLists.txt assumes libpredict and its development files are
 installed on the system.

--- a/examples/setrise/CMakeLists.txt
+++ b/examples/setrise/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(setrise-example C)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+
+add_executable(setrise-example main.c)
+target_link_libraries(setrise-example predict)

--- a/examples/setrise/main.c
+++ b/examples/setrise/main.c
@@ -9,7 +9,7 @@
 double observer_next_sunset(const predict_observer_t *observer, double time, struct predict_observation *obs)
 {
 	struct predict_observation sun;
-	
+
 	// Scan for first elevation > 0 (t0)
 	double t0 = time;
 	predict_observe_sun(observer, t0, &sun);
@@ -25,8 +25,7 @@ double observer_next_sunset(const predict_observer_t *observer, double time, str
 		t1 += 1.0/24.0/3600.0;
 		predict_observe_sun(observer, t1, &sun);
 	}
-	
-//	int i = 0;
+
 	while ( fabs(t0-t1) > 0.01/24/3600 ) {
 
 		time = (t0 + t1) / 2.0;
@@ -35,7 +34,6 @@ double observer_next_sunset(const predict_observer_t *observer, double time, str
 		if (sun.elevation > 0) t0 = time;
 		else t1 = time;
 
-//		printf("iteration %i: elev=%f\n", i++, sun.elevation*180.0/M_PI);
 	}
 
 	if (obs != NULL) {
@@ -48,7 +46,7 @@ double observer_next_sunset(const predict_observer_t *observer, double time, str
 double observer_next_sunrise(const predict_observer_t *observer, double time, struct predict_observation *obs)
 {
 	struct predict_observation sun;
-	
+
 	// Scan for first elevation < 0 (t0)
 	double t0 = time;
 	predict_observe_sun(observer, t0, &sun);
@@ -64,8 +62,7 @@ double observer_next_sunrise(const predict_observer_t *observer, double time, st
 		t1 += 1.0/24.0/3600.0;
 		predict_observe_sun(observer, t1, &sun);
 	}
-	
-//	int i = 0;
+
 	while ( fabs(t0-t1) > 0.01/24/3600 ) {
 
 		time = (t0 + t1) / 2.0;
@@ -74,9 +71,8 @@ double observer_next_sunrise(const predict_observer_t *observer, double time, st
 		if (sun.elevation < 0) t0 = time;
 		else t1 = time;
 
-	//	printf("iteration %i: elev=%f\n", i++, sun.elevation*180.0/M_PI);
 	}
-	
+
 	if (obs != NULL) {
 		memcpy(obs, &sun, sizeof(struct predict_observation));
 	}
@@ -93,7 +89,7 @@ int main(int argc, char **argv)
 		fprintf(stderr, "Failed to initialize observer!");
 		exit(1);
 	}
-		
+
 	predict_julian_date_t curr_time = predict_to_julian(time(NULL));
 
 	struct predict_observation sun;
@@ -104,10 +100,10 @@ int main(int argc, char **argv)
 	int h = timeto / 3600;
 	int m = (timeto-h*3600) / 60;
 	int s = ((int)timeto)%60;
-	
+
 	time_t t = (time_t)(86400.0 * (sunset + 3651.0));
 	printf("Next sunset in %02i:%02i:%02i, azimuth=%.1f, at UTC %s", h, m, s, sun.azimuth*180.0/M_PI, asctime(gmtime(&t)));
-	
+
 	double sunrise = observer_next_sunrise(obs, curr_time, &sun);
 
 	// Convert to hour, minute, seconds
@@ -115,10 +111,10 @@ int main(int argc, char **argv)
 	h = timeto / 3600;
 	m = (timeto-h*3600) / 60;
 	s = ((int)timeto)%60;
-	
+
 	t = (time_t)(86400.0 * (sunrise + 3651.0));
 	printf("Next sunrise in %02i:%02i:%02i, azimuth=%.1f, at UTC %s", h, m, s, sun.azimuth*180.0/M_PI, asctime(gmtime(&t)));
-	
+
 	// Free memory
 	predict_destroy_observer(obs);
 


### PR DESCRIPTION
Fixes issue #51. Examples can be compiled again.

Also changed the printing in the basic example a bit, by clearing the screen and printing on top of the terminal (making it seem like numbers are updated instead of being printed row by row once every second). Makefile was also exchanged by CMakeLists.txt-files. Examples was added to travis build so that broken examples don't have to happen again. 