### PR TITLE
Issue62 - Prediction of maximum elevation

### DIFF
--- a/include/predict/predict.h.in
+++ b/include/predict/predict.h.in
@@ -336,6 +336,14 @@ predict_julian_date_t predict_next_aos(const predict_observer_t *observer, const
  **/
 predict_julian_date_t predict_next_los(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, predict_julian_date_t start_time);
 
+/**
+ * Find maximum elevation of next or current pass.
+ *
+ * \param observer Ground station
+ * \param orbital_elements Orbital elements of satellite
+ * \param start_time Search time. If elevation is negative, max elevation is sought from the start_time and on. If elevation is positive, max elevation is searched for within the current pass
+ * \return Time for maximum elevation
+ **/
 predict_julian_date_t predict_max_elevation(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, predict_julian_date_t start_time);
 
 /**

--- a/include/predict/predict.h.in
+++ b/include/predict/predict.h.in
@@ -342,9 +342,9 @@ predict_julian_date_t predict_next_los(const predict_observer_t *observer, const
  * \param observer Ground station
  * \param orbital_elements Orbital elements of satellite
  * \param start_time Search time. If elevation is negative, max elevation is sought from the start_time and on. If elevation is positive, max elevation is searched for within the current pass
- * \return Time for maximum elevation
+ * \return Observed properties at maximum elevation
  **/
-predict_julian_date_t predict_max_elevation(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, predict_julian_date_t start_time);
+struct predict_observation predict_at_max_elevation(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, predict_julian_date_t start_time);
 
 /**
  * Calculate doppler shift of a given downlink frequency with respect to the observer. 

--- a/include/predict/predict.h.in
+++ b/include/predict/predict.h.in
@@ -336,6 +336,8 @@ predict_julian_date_t predict_next_aos(const predict_observer_t *observer, const
  **/
 predict_julian_date_t predict_next_los(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, predict_julian_date_t start_time);
 
+predict_julian_date_t predict_max_elevation(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, predict_julian_date_t start_time);
+
 /**
  * Calculate doppler shift of a given downlink frequency with respect to the observer. 
  *

--- a/src/libpredict.symver
+++ b/src/libpredict.symver
@@ -23,7 +23,7 @@ VER_0.1 {
 		predict_observe_sun;
 		predict_next_aos;
 		predict_next_los;
-		predict_max_elevation;
+		predict_at_max_elevation;
 		predict_doppler_shift;
 		predict_refraction;
 		predict_refraction_ext;

--- a/src/libpredict.symver
+++ b/src/libpredict.symver
@@ -23,6 +23,7 @@ VER_0.1 {
 		predict_observe_sun;
 		predict_next_aos;
 		predict_next_los;
+		predict_max_elevation;
 		predict_doppler_shift;
 		predict_refraction;
 		predict_refraction_ext;

--- a/src/observer.c
+++ b/src/observer.c
@@ -583,17 +583,19 @@ struct predict_observation find_max_elevation(const predict_observer_t *observer
 	return observation;
 }
 
-predict_julian_date_t predict_max_elevation(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, predict_julian_date_t start_time)
+struct predict_observation predict_at_max_elevation(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, predict_julian_date_t start_time)
 {
+	struct predict_observation ret_observation = {0};
+
 	if (predict_is_geostationary(orbital_elements)) {
-		return 0;
+		return ret_observation;
 	}
 
 	struct predict_orbit orbit;
 	struct predict_observation observation;
 	predict_orbit(orbital_elements, &orbit, start_time);
 	if (orbit.decayed) {
-		return 0;
+		return ret_observation;
 	}
 
 	predict_observe_orbit(observer, &orbit, &observation);
@@ -619,11 +621,11 @@ predict_julian_date_t predict_max_elevation(const predict_observer_t *observer, 
 
 	//return the best candidate
 	if ((candidate_center.elevation > candidate_lower.elevation) && (candidate_center.elevation > candidate_upper.elevation)) {
-		return candidate_center.time;
+		return candidate_center;
 	} else if (candidate_lower.elevation > candidate_upper.elevation) {
-		return candidate_lower.time;
+		return candidate_lower;
 	} else {
-		return candidate_upper.time;
+		return candidate_upper;
 	}
 }
 

--- a/src/observer.c
+++ b/src/observer.c
@@ -53,6 +53,7 @@ void predict_observe_orbit(const predict_observer_t *observer, const struct pred
 	if (!(orbit->eclipsed) && (sun_obs.elevation*180.0/M_PI < VISIBILITY_SUN_ELE_UPPER_THRESH) && (obs->elevation*180.0/M_PI > VISIBILITY_ORBIT_ELE_LOWER_THRESH)) {
 		obs->visible = true;
 	}
+	obs->time = orbit->time;
 }
 
 void observer_calculate(const predict_observer_t *observer, double time, const double pos[3], const double vel[3], struct predict_observation *result)
@@ -401,34 +402,31 @@ double predict_next_aos(const predict_observer_t *observer, const predict_orbita
 	double curr_time = start_utc;
 	struct predict_observation obs;
 	double time_step = 0;
-	
+
 	struct predict_orbit orbit;
 	predict_orbit(orbital_elements, &orbit, curr_time);
 	predict_observe_orbit(observer, &orbit, &obs);
 
 	//check whether AOS can happen after specified start time
-	if (predict_aos_happens(orbital_elements, observer->latitude) && !predict_is_geostationary(orbital_elements) && !orbit.decayed)
-	{
-		//TODO: Time steps have been found in FindAOS/LOS(). 
+	if (predict_aos_happens(orbital_elements, observer->latitude) && !predict_is_geostationary(orbital_elements) && !orbit.decayed) {
+		//TODO: Time steps have been found in FindAOS/LOS().
 		//Might be based on some pre-existing source, root-finding techniques
 		//or something. Find them, and improve readability of the code and so that
-		//the mathematical stability of the iteration can be checked. 
-		//Bisection method, Brent's algorithm? Given a coherent root finding algorithm, 
-		//can rather have one function for iterating the orbit and then let get_next_aos/los 
-		//specify bounding intervals for the root finding. 
+		//the mathematical stability of the iteration can be checked.
+		//Bisection method, Brent's algorithm? Given a coherent root finding algorithm,
+		//can rather have one function for iterating the orbit and then let get_next_aos/los
+		//specify bounding intervals for the root finding.
 
-		//skip the rest of the pass if the satellite is currently in range, since we want the _next_ AOS. 
-		if (obs.elevation > 0.0)
-		{
+		//skip the rest of the pass if the satellite is currently in range, since we want the _next_ AOS.
+		if (obs.elevation > 0.0) {
 			curr_time = predict_next_los(observer, orbital_elements, curr_time);
-			curr_time += DAYNUM_MINUTE*20; //skip 20 minutes. LOS might still be within the elevation threshold. (rough quickfix from predict) 
+			curr_time += DAYNUM_MINUTE*20; //skip 20 minutes. LOS might still be within the elevation threshold. (rough quickfix from predict)
 			predict_orbit(orbital_elements, &orbit, curr_time);
 			predict_observe_orbit(observer, &orbit, &obs);
 		}
 
 		//iteration until the orbit is roughly in range again, before the satellite pass
-		while ((obs.elevation*180.0/M_PI < -1.0) || (obs.elevation_rate < 0))
-		{
+		while ((obs.elevation*180.0/M_PI < -1.0) || (obs.elevation_rate < 0)) {
 			time_step = 0.00035*(obs.elevation*180.0/M_PI*((orbit.altitude/8400.0)+0.46)-2.0);
 			curr_time -= time_step;
 			predict_orbit(orbital_elements, &orbit, curr_time);
@@ -436,8 +434,7 @@ double predict_next_aos(const predict_observer_t *observer, const predict_orbita
 		}
 
 		//fine tune the results until the elevation is within a low enough threshold
-		while (fabs(obs.elevation*180/M_PI) > ELEVATION_ZERO_TOLERANCE)
-		{
+		while (fabs(obs.elevation*180/M_PI) > ELEVATION_ZERO_TOLERANCE) {
 			time_step = obs.elevation*180.0/M_PI*sqrt(orbit.altitude)/530000.0;
 			curr_time -= time_step;
 			predict_orbit(orbital_elements, &orbit, curr_time);
@@ -447,6 +444,39 @@ double predict_next_aos(const predict_observer_t *observer, const predict_orbita
 		ret_aos_time = curr_time;
 	}
 	return ret_aos_time;
+}
+
+/**
+ * Pass stepping direction used for pass stepping function below.
+ **/
+enum step_pass_direction{POSITIVE_DIRECTION, NEGATIVE_DIRECTION};
+
+/**
+ * Rough stepping through a pass. Uses weird time steps from Predict.
+ *
+ * \param observer Ground station
+ * \param orbital_elements Orbital elements of satellite
+ * \param curr_time Time from which to start stepping
+ * \param direction Either POSITIVE_DIRECTION (step from current time to pass end) or NEGATIVE_DIRECTION (step from current time to start of pass). In case of the former, the pass will be stepped until either elevation is negative or the derivative of the elevation is negative
+ * \return Time for when we have stepped out of the pass
+ * \copyright GPLv2+
+ **/
+double step_pass(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, double curr_time, enum step_pass_direction direction) {
+	struct predict_orbit orbit;
+	struct predict_observation obs;
+	do {
+		predict_orbit(orbital_elements, &orbit, curr_time);
+		predict_observe_orbit(observer, &orbit, &obs);
+
+		//weird time stepping from Predict, but which magically works
+		double time_step = cos(obs.elevation - 1.0)*sqrt(orbit.altitude)/25000.0;
+		if (((direction == POSITIVE_DIRECTION) && time_step < 0) || ((direction == NEGATIVE_DIRECTION) && time_step > 0)) {
+			time_step = -time_step;
+		}
+
+		curr_time += time_step;
+	} while ((obs.elevation >= 0) || ((direction == POSITIVE_DIRECTION) && (obs.elevation_rate > 0.0)));
+	return curr_time;
 }
 
 double predict_next_los(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, double start_utc)
@@ -461,41 +491,26 @@ double predict_next_los(const predict_observer_t *observer, const predict_orbita
 	predict_observe_orbit(observer, &orbit, &obs);
 
 	//check whether AOS/LOS can happen after specified start time
-	if (predict_aos_happens(orbital_elements, observer->latitude) && !predict_is_geostationary(orbital_elements) && !orbit.decayed)
-	{
+	if (predict_aos_happens(orbital_elements, observer->latitude) && !predict_is_geostationary(orbital_elements) && !orbit.decayed) {
 		//iteration algorithm from Predict, see comments in predict_next_aos().
 
 		//iterate until next satellite pass
-		if (obs.elevation < 0.0)
-		{
+		if (obs.elevation < 0.0) {
 			curr_time = predict_next_aos(observer, orbital_elements, curr_time);
 			predict_orbit(orbital_elements, &orbit, curr_time);
 			predict_observe_orbit(observer, &orbit, &obs);
 		}
 
 		//step through the pass
-		do 
-		{
-			time_step = cos(obs.elevation - 1.0)*sqrt(orbit.altitude)/25000.0;
-			if (time_step < 0) {
-				time_step = -time_step;
-			}
+		curr_time = step_pass(observer, orbital_elements, curr_time, POSITIVE_DIRECTION);
 
-			curr_time += time_step;
-			predict_orbit(orbital_elements, &orbit, curr_time);
-			predict_observe_orbit(observer, &orbit, &obs);
-		} 
-		while ((obs.elevation >= 0.0) || (obs.elevation_rate > 0.0));
-		
 		//fine tune to elevation threshold
-		do 
-		{
+		do {
 			time_step = obs.elevation*180.0/M_PI*sqrt(orbit.altitude)/502500.0;
 			curr_time += time_step;
 			predict_orbit(orbital_elements, &orbit, curr_time);
 			predict_observe_orbit(observer, &orbit, &obs);
-		}
-		while (fabs(obs.elevation*180.0/M_PI) > ELEVATION_ZERO_TOLERANCE);
+		} while (fabs(obs.elevation*180.0/M_PI) > ELEVATION_ZERO_TOLERANCE);
 
 		ret_los_time = curr_time;
 	}
@@ -503,7 +518,14 @@ double predict_next_los(const predict_observer_t *observer, const predict_orbita
 
 }
 
-
+/**
+ * Convenience function for calculation of derivative of elevation at specific time.
+ *
+ * \param observer Ground station
+ * \param orbital_elements Orbital elements for satellite
+ * \param time Time
+ * \return Derivative of elevation at input time
+ **/
 double elevation_derivative(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, double time)
 {
 	struct predict_orbit orbit;
@@ -514,38 +536,25 @@ double elevation_derivative(const predict_observer_t *observer, const predict_or
 }
 
 #include <float.h>
+
+//Threshold used for comparing lower and upper brackets in find_max_elevation
 #define TIME_THRESHOLD FLT_EPSILON
+
+//Maximum number of iterations in find_max_elevation
 #define MAX_ITERATIONS 10000
-predict_julian_date_t predict_max_elevation(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, predict_julian_date_t start_time)
+
+/**
+ * Find maximum elevation bracketed by input lower and upper time.
+ *
+ * \param observer Ground station
+ * \param orbital_elements Orbital elements of satellite
+ * \param lower_time Lower time bracket
+ * \param upper_time Upper time bracket
+ * \return Observation of satellite for maximum elevation between lower and upper time brackets
+ **/
+struct predict_observation find_max_elevation(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, double lower_time, double upper_time)
 {
-	if (predict_is_geostationary(orbital_elements)) {// || orbital_elements->decayed) {
-		return 0;
-	}
-
-	struct predict_orbit orbit;
-	struct predict_observation observation;
-	predict_orbit(orbital_elements, &orbit, start_time);
-	predict_observe_orbit(observer, &orbit, &observation);
-
-	double lower_time;
-	if (observation.elevation < 0) {
-		//bracket the maximum by AOS and LOS if we have elevation < 0
-		lower_time = predict_next_aos(observer, orbital_elements, start_time);
-	} else if ((observation.elevation >= 0) && (observation.elevation_rate > 0)) {
-		//we are on increasing side of the maximum, so can use the start time as lower bound
-		lower_time = start_time;
-	} else {
-		//elevation nonnegative and time is after max elevation, need to backtrack, choosing to backtrack one half orbital period
-		start_time -= 0.5/orbital_elements->mean_motion;
-		double next_aos = predict_next_aos(observer, orbital_elements, start_time);
-		lower_time = next_aos;
-	}
-
-	//bracket upper part by LOS of current pass
-	double upper_time = predict_next_los(observer, orbital_elements, lower_time);
-
-	//find maximum by applying Brent's algorithm on the elevation rate
-	double max_ele_time_candidate = 0;
+	double max_ele_time_candidate = (upper_time + lower_time)/2.0;
 	int iteration = 0;
 	while ((fabs(lower_time - upper_time) > TIME_THRESHOLD) && (iteration < MAX_ITERATIONS)) {
 		max_ele_time_candidate = (upper_time + lower_time)/2.0;
@@ -565,7 +574,57 @@ predict_julian_date_t predict_max_elevation(const predict_observer_t *observer, 
 		}
 		iteration++;
 	}
-	return max_ele_time_candidate;
+
+	//prepare output
+	struct predict_orbit orbit;
+	struct predict_observation observation;
+	predict_orbit(orbital_elements, &orbit, max_ele_time_candidate);
+	predict_observe_orbit(observer, &orbit, &observation);
+	return observation;
+}
+
+predict_julian_date_t predict_max_elevation(const predict_observer_t *observer, const predict_orbital_elements_t *orbital_elements, predict_julian_date_t start_time)
+{
+	if (predict_is_geostationary(orbital_elements)) {
+		return 0;
+	}
+
+	struct predict_orbit orbit;
+	struct predict_observation observation;
+	predict_orbit(orbital_elements, &orbit, start_time);
+	if (orbit.decayed) {
+		return 0;
+	}
+
+	predict_observe_orbit(observer, &orbit, &observation);
+
+	//bracket the solution by approximate times for AOS and LOS of the current or next pass
+	double lower_time = start_time;
+	double upper_time = start_time;
+	if (observation.elevation < 0) {
+		lower_time = predict_next_aos(observer, orbital_elements, start_time);
+	} else {
+		lower_time = step_pass(observer, orbital_elements, lower_time, NEGATIVE_DIRECTION);
+	}
+	upper_time = predict_next_los(observer, orbital_elements, lower_time);
+
+	//assume that we can only have two potential local maxima along the elevation curve, and be content with that. For most cases, we will only have one, unless it is a satellite in deep space with long passes and weird effects.
+
+	//bracket by AOS/LOS
+	struct predict_observation candidate_center = find_max_elevation(observer, orbital_elements, lower_time, upper_time);
+
+	//bracket by a combination of the found candidate above and either AOS or LOS (will thus cover solutions within [aos, candidate] and [candidate, los])
+	struct predict_observation candidate_lower = find_max_elevation(observer, orbital_elements, candidate_center.time - TIME_THRESHOLD, upper_time);
+	struct predict_observation candidate_upper = find_max_elevation(observer, orbital_elements, lower_time, candidate_center.time + TIME_THRESHOLD);
+
+	//return the best candidate
+	if ((candidate_center.elevation > candidate_lower.elevation) && (candidate_center.elevation > candidate_upper.elevation)) {
+		return candidate_center.time;
+	} else if (candidate_lower.elevation > candidate_upper.elevation) {
+		return candidate_lower.time;
+	} else {
+		return candidate_upper.time;
+	}
 }
 
 double predict_doppler_shift(const predict_observer_t *observer, const struct predict_orbit *orbit, double frequency)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,3 +42,12 @@ foreach(file ${files})
 	get_filename_component(testname ${file} NAME_WE)
 	add_test(NAME ${testname} COMMAND moon-t ${file})
 endforeach()
+
+#test max elevation function
+add_executable(maxelevation-t maxelevation-t.cpp testcase_reader.cpp)
+target_link_libraries(maxelevation-t predict)
+file(GLOB files "${LIBPREDICT_TEST_DATA_DIR}/sat_*.test")
+foreach(file ${files})
+	get_filename_component(testname ${file} NAME_WE)
+	add_test(NAME maxelevation-${testname} COMMAND maxelevation-t ${file})
+endforeach()

--- a/tests/aoslos-t.cpp
+++ b/tests/aoslos-t.cpp
@@ -32,6 +32,17 @@ int main(int argc, char **argv)
 	return retval;
 }
 
+/**
+ * Predict AOS/LOS for several passes after the start time, and check that the times are consistent with each other, that elevation is non-zero in the center
+ * and that the elevation rates are correct at each point.
+ *
+ * \param orbital_elements Orbital elements
+ * \param observer Observer
+ * \param start_time Start time
+ * \return 0 on success, -1 on failure
+ **/
+int aoslos_timepoint_consistency_test(predict_orbital_elements_t *orbital_elements, predict_observer_t *observer, double start_time);
+
 int runtest(const char *filename)
 {
 	// Load testcase
@@ -56,59 +67,93 @@ int runtest(const char *filename)
 		fprintf(stderr, "Failed to initialize observer!");
 		return -1;
 	}
-	
-	int retval = 0;
-	int line = 1;
 
 	// Use first available time as start time for AOS/LOS finding
-	double start_time = testcase.data()[0][0];
+	double start_time = predict_to_julian(testcase.data()[0][0]);
 
-	predict_julian_date_t next_aos_time = predict_next_aos(obs, orbital_elements, predict_to_julian(start_time));
-	predict_julian_date_t next_los_time = predict_next_los(obs, orbital_elements, predict_to_julian(start_time)); //can be LOS of current pass, if satellite is in range
-	
-	double time_diff = 1.0/(60.0*60.0*24.0); //1 second
-	predict_julian_date_t curr_time = predict_to_julian(start_time);
-
-	const double ELEVATION_THRESH = 0.3; //this elevation threshold was used internal AOS/LOS calculations, so should hold also here.
-
-	// Check times until the AOS
-	while (curr_time < next_aos_time) {
-		struct predict_observation orbit_obs;
-		predict_orbit(orbital_elements, &orbit, curr_time);
-		predict_observe_orbit(obs, &orbit, &orbit_obs);
-
-		if ((next_los_time < next_aos_time) && (curr_time < next_los_time)) {
-			//satellite should be above the horizon (satellite was in range at the start time)
-			if (orbit_obs.elevation*180/M_PI < -ELEVATION_THRESH) {
-				fprintf(stderr, "AOS failed sanity check: Satellite currently in range according to LOS/AOS state, but not above the horizon. Elevation: %f\n", orbit_obs.elevation*180/M_PI);
-				return -1;
-			}
-		} else if (curr_time < next_aos_time) {
-			//satellite should be below the horizon
-			if (orbit_obs.elevation*180/M_PI > ELEVATION_THRESH){
-				fprintf(stderr, "AOS failed sanity check: Satellite has not reached AOS, but is above the horizon. Elevation: %f\n", orbit_obs.elevation*180/M_PI);
-				return -1;
-			}
-		} 
-		curr_time += time_diff;
+	//check whether the pass makes sense wrt elevation and/or elevation rate at start, end and middle of pass
+	if (aoslos_timepoint_consistency_test(orbital_elements, obs, start_time) != 0) {
+		return -1;
 	}
 
-	// Check times up till LOS
-	next_los_time = predict_next_los(obs, orbital_elements, predict_to_julian(curr_time)); //recalculating within the pass in case LOS was for previous pass
-	while (curr_time < next_los_time) {
-		struct predict_observation orbit_obs;
-		predict_orbit(orbital_elements, &orbit, curr_time);
-		predict_observe_orbit(obs, &orbit, &orbit_obs);
+	return 0;
+}
 
-		//satellite should be above the horizon
-		if (orbit_obs.elevation*180/M_PI < -ELEVATION_THRESH) {
-			fprintf(stderr, "AOS/LOS failed sanity check: Satellite has reached AOS, waiting for LOS, but not above the horizon. Elevation: %f\n", orbit_obs.elevation*180/M_PI);
+//The tolerance used for fine-tuning the elevations in the aoslos-functions
+#define ELEVATION_ZERO_TOLERANCE 0.3
+
+//Expected time between two passes should at least be 20 minutes
+#define PASS_TIME_THRESH (20.0/(24*60))
+
+int aoslos_timepoint_consistency_test(predict_orbital_elements_t *orbital_elements, predict_observer_t *observer, double start_time)
+{
+	if (predict_is_geostationary(orbital_elements)) {
+		return 0;
+	}
+
+	double aos_time = predict_next_aos(observer, orbital_elements, start_time);
+	double los_time = predict_next_los(observer, orbital_elements, aos_time);
+
+	struct predict_orbit orbit;
+	struct predict_observation observation;
+
+	const int NUM_PASSES = 10;
+	for (int i=0; i < NUM_PASSES; i++) {
+		if (los_time <= aos_time) {
+			fprintf(stderr, "los time not strictly larger than aos time: %f %f\n", aos_time, los_time);
 			return -1;
 		}
-		
-		
-		curr_time += time_diff;
+
+		predict_orbit(orbital_elements, &orbit, aos_time);
+		predict_observe_orbit(observer, &orbit, &observation);
+		double elevation_rate_aos = observation.elevation_rate;
+
+		predict_orbit(orbital_elements, &orbit, los_time);
+		predict_observe_orbit(observer, &orbit, &observation);
+		double elevation_rate_los = observation.elevation_rate;
+
+		if ((elevation_rate_aos <= 0) || (elevation_rate_los >= 0)) {
+			fprintf(stderr, "Elevation rates do not have correct signs for aos and los times: %f (%f) %f (%f)\n", elevation_rate_aos, aos_time, elevation_rate_los, los_time);
+			return -1;
+		}
+
+		double midpass = (los_time - aos_time)/2.0 + aos_time;
+		predict_orbit(orbital_elements, &orbit, midpass);
+		predict_observe_orbit(observer, &orbit, &observation);
+
+		if (observation.elevation <= 0.0) {
+			fprintf(stderr, "Elevation is negative during the middle of a pass: %f %f %f\n", aos_time, midpass, los_time);
+			return -1;
+		}
+
+		double prev_los_time = los_time;
+		double prev_aos_time = aos_time;
+		aos_time = predict_next_aos(observer, orbital_elements, los_time);
+		los_time = predict_next_los(observer, orbital_elements, aos_time);
+
+		if (!((los_time > aos_time) && (los_time > prev_los_time) && (los_time > prev_aos_time) && (aos_time > prev_los_time))) {
+			fprintf(stderr, "New AOS/LOS not strictly larger than previous AOS/LOS\n");
+			return -1;
+		}
+
+		if ((aos_time - prev_los_time) < PASS_TIME_THRESH) {
+			fprintf(stderr, "Time between passes not significantly different: %f minutes\n", (aos_time - prev_los_time)*24*60);
+			return -1;
+		}
+
+		//check that time between LOS time and next AOS time produces negative elevations
+		double timestep = 1.0/(24.0*50);
+		double curr_time = prev_los_time + timestep;
+		while (curr_time < aos_time - timestep) {
+			predict_orbit(orbital_elements, &orbit, curr_time);
+			predict_observe_orbit(observer, &orbit, &observation);
+			if (observation.elevation*180.0/M_PI >= ELEVATION_ZERO_TOLERANCE) {
+				fprintf(stderr, "AOS/LOS failed consistency check between two passes: %f %f %f %f\n", curr_time, observation.elevation, prev_los_time, aos_time);
+				return -1;
+			}
+			curr_time += timestep;
+		}
 	}
 
-	return retval;
+	return 0;
 }

--- a/tests/maxelevation-t.cpp
+++ b/tests/maxelevation-t.cpp
@@ -1,0 +1,247 @@
+#include <stdio.h>
+#include <vector>
+#include <math.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <predict/predict.h>
+#include "testcase_reader.h"
+#include <iostream>
+using namespace std;
+
+int runtest(const char *filename);
+
+int main(int argc, char **argv)
+{
+	//check arguments
+	if (argc < 2) {
+		cout << "Usage: " << argv[0] << " <testfiles>" << endl;
+		return -1;
+	}
+
+	//test all provided test files
+	int retval = 0;
+	for (int i = 1; i < argc; ++i) {
+		if (runtest(argv[i])) {
+			cout << argv[i] << ": failed" << endl;
+			retval = -1;
+		} else {
+			cout << argv[i] << ": OK" << endl;
+		}
+	}
+
+	return retval;
+}
+
+#include <float.h>
+
+//precision of numerical tests
+const double EPSILON = 2*FLT_EPSILON;
+
+/**
+ * Let predict_at_max_elevation go through a couple of sanity tests:
+ * - Check that max elevation time is within AOS/LOS of the pass
+ * - Check if the derivative crosses the zero boundary
+ * - Check that the elevation is non-zero
+ * - Check that rough sampling of the elevation throughout the pass does not yield higher elevations
+ * - Check that when the max elevation time is used as the input, the same max elevation time is returned
+ * - Check that the same max elevation time is returned regardless of the input time throughout the pass
+ * This is done for NUM_PASSES different passes, found from the input time.
+ *
+ * \param start_time Input start time
+ * \param observer Observer
+ * \param orbital_elements Orbital elements of satellite
+ * \return 0 on success, -1 on failure
+ **/
+int test_max_elevation(double start_time, predict_observer_t *observer, predict_orbital_elements_t *orbital_elements);
+
+int runtest(const char *filename)
+{
+	//load testcase
+	TestCaseReader testcase;
+	testcase.loadFromFile(filename);
+	if (!(testcase.containsValidData() && (testcase.containsValidQth()) && (testcase.containsValidTLE()))) {
+		fprintf(stderr, "Failed to load testfile: %s\n", filename);
+		return -1;
+	}
+
+	//get TLE
+	char *tle[2];
+	testcase.getTLE(tle);
+
+	//create orbit object
+	predict_orbital_elements_t *orbital_elements = predict_parse_tle(tle[0], tle[1]);
+
+	if (predict_is_geostationary(orbital_elements)) {
+		return 0;
+	}
+
+	//test at the standard defined QTH
+	double start_time = predict_to_julian(testcase.data()[0][0]);
+	predict_observer_t *observer = predict_create_observer("test", testcase.latitude()*M_PI/180.0, testcase.longitude()*M_PI/180.0, testcase.altitude());
+	if (test_max_elevation(start_time, observer, orbital_elements) != 0) {
+		fprintf(stderr, "Failed on fixed QTH.\n");
+		return -1;
+	}
+
+	//test at a QTH that is located exactly on the satellite track, so that elevation should be 90 degrees (and thus potentially a bit problematic with the derivative)
+	struct predict_orbit orbit;
+	struct predict_observation obs;
+	predict_orbit(orbital_elements, &orbit, start_time);
+	observer = predict_create_observer("problematic", orbit.latitude, orbit.longitude, 0);
+	double max_elevation_time = start_time;
+
+	//test that the elevation actually is 90.0
+	predict_observe_orbit(observer, &orbit, &obs);
+	if (!fuzzyCompare(obs.elevation, M_PI/2.0, EPSILON)) {
+		fprintf(stderr, "Our QTH does not observe a 90 degrees elevation as it should, something wrong with test: %f\n", obs.elevation*180.0/M_PI);
+		return -1;
+	}
+
+	//find a time slightly before the pass with elevation less than 0
+	double revolution_fraction = 1.0/orbital_elements->mean_motion/12.0;
+	while (obs.elevation > 0) {
+		start_time -= revolution_fraction;
+		predict_orbit(orbital_elements, &orbit, start_time);
+		predict_observe_orbit(observer, &orbit, &obs);
+	}
+
+	//find AOS/LOS of pass with elevation 90 degrees
+	double next_aos = predict_next_aos(observer, orbital_elements, start_time);
+	double next_los = predict_next_los(observer, orbital_elements, next_aos);
+	if (!((max_elevation_time > next_aos) && (max_elevation_time < next_los))) {
+		fprintf(stderr, "Error in preparing pass times.\n");
+		return -1;
+	}
+
+	//test that time predicted from start_time before the 90 degrees pass corresponds to the theoretical maximum elevation
+	struct predict_observation max_ele_time_from_start = predict_at_max_elevation(observer, orbital_elements, start_time);
+	if (!fuzzyCompare(max_elevation_time, max_ele_time_from_start.time, EPSILON)) {
+		fprintf(stderr, "Failed on predicting max elevation corresponding to theoretical 90 degrees time: new = %f, orig = %f\n", max_ele_time_from_start.time, max_elevation_time);
+		return -1;
+	}
+
+	//test that we get back the theoretical maximum elevation when predicting from theoretical maximum elevation time
+	struct predict_observation max_ele_at_max_elevation = predict_at_max_elevation(observer, orbital_elements, max_elevation_time);
+	if (!fuzzyCompare(max_elevation_time, max_ele_at_max_elevation.time, EPSILON)) {
+		fprintf(stderr, "Failed on predicting the same max elevation as input max elevation for 90 degrees elevation: new = %f, orig = %f\n", max_ele_at_max_elevation.time, max_elevation_time);
+		return -1;
+	}
+
+
+	//check that max elevation for times before a pass are correct, and that the rest of the sanity checks are correct for our 90 degrees elevation test qth
+	if (test_max_elevation(start_time, observer, orbital_elements) != 0) {
+		fprintf(stderr, "Failed on QTH placed directly under the satellite.\n");
+		return -1;
+	}
+	return 0;
+}
+
+//threshold for pass length in order to avoid errors in AOS/LOS finding functions triggering an error in the max elevation tests
+#define PASS_LENGTH_THRESHOLD (3.0/(24.0*60))
+
+//number of passes to check
+#define NUM_PASSES 20
+
+//skip one day between each time point we will predict a pass and check the max elevation
+#define TIME_DIFF 1
+
+//number of times we will sample the elevation throughout a pass to roughly check agains the predicted max elevation
+#define NUM_TIME_STEPS 10
+
+int test_max_elevation(double start_time, predict_observer_t *observer, predict_orbital_elements_t *orbital_elements)
+{
+	double orig_start_time = start_time;
+	struct predict_orbit orbit;
+	struct predict_observation obs;
+
+	for (int i=0; i < NUM_PASSES; i++) {
+		start_time += i*TIME_DIFF;
+
+		predict_orbit(orbital_elements, &orbit, start_time);
+		predict_observe_orbit(observer, &orbit, &obs);
+
+		//one fifth of the total revolution around earth
+		double revolution_fraction = 1.0/orbital_elements->mean_motion/5.0;
+
+		//skip to time where current elevation is less than 0 (i.e. skip ahead some time along the revolution around earth)
+		if (obs.elevation > 0) {
+			start_time = predict_next_los(observer, orbital_elements, start_time) + revolution_fraction;
+			while (obs.elevation > 0) {
+				start_time += revolution_fraction;
+				predict_orbit(orbital_elements, &orbit, start_time);
+				predict_observe_orbit(observer, &orbit, &obs);
+			}
+		}
+
+		//get times from next pass
+		predict_julian_date_t next_aos_time = predict_next_aos(observer, orbital_elements, start_time);
+		predict_julian_date_t next_los_time = predict_next_los(observer, orbital_elements, next_aos_time);
+		struct predict_observation max_elevation_obs = predict_at_max_elevation(observer, orbital_elements, start_time);
+		double max_elevation = max_elevation_obs.elevation;
+
+		//check if max elevation time is within aos/los-times
+		if (!((max_elevation_obs.time > next_aos_time) && (max_elevation_obs.time < next_los_time))) {
+			fprintf(stderr, "Predicted elevation time not within times for AOS and LOS: predicted time %f, aos %f, los %f\n", max_elevation_obs.time, next_aos_time, next_los_time);
+			return -1;
+		}
+
+		//check if derivative on either side of the estimated solution crosses the zero boundary
+		predict_orbit(orbital_elements, &orbit, max_elevation_obs.time-EPSILON);
+		predict_observe_orbit(observer, &orbit, &obs);
+		double lower_derivative = obs.elevation_rate;
+		predict_orbit(orbital_elements, &orbit, max_elevation_obs.time+EPSILON);
+		predict_observe_orbit(observer, &orbit, &obs);
+		double upper_derivative = obs.elevation_rate;
+		if (!((upper_derivative < 0) && (lower_derivative > 0))) {
+			fprintf(stderr, "First derivative of elevation not zero: %f %f %f\n", max_elevation_obs.time, lower_derivative, upper_derivative);
+			return -1;
+		}
+
+		//check if the found max elevation rate is larger than all other elevations sampled throughout the pass
+		for (int i=0; i < NUM_TIME_STEPS; i++) {
+			double time = next_aos_time + i*(next_los_time - next_aos_time)/NUM_TIME_STEPS;
+			predict_orbit(orbital_elements, &orbit, time);
+			predict_observe_orbit(observer, &orbit, &obs);
+			if (max_elevation < obs.elevation - EPSILON) {
+				fprintf(stderr, "Found elevation through the pass larger than the max elevation: %f, %f\n", max_elevation, obs.elevation);
+				return -1;
+			}
+		}
+
+		//check that the difference between AOS/LOS time is larger than a threshold, and stop the rest of the tests if not (aos/los-functions will detect almost-passes very close to the horizon as actual passes, due to the set thresholds and behavior of the pass finding functions: See issue #18 in the git repository. This will be taken care of among the AOS/LOS tests once the issue is fixed). Predicted max elevation
+		//will not fail basic tests above (derivative, actual maximum), but will fail the more nasty tests below since they assume more perfect AOS/LOS timepoints. TODO:
+		//Remove this check once issue #18 is fixed, and we have new and more numerically stable aos/los functions.
+		if ((next_los_time - next_aos_time) < PASS_LENGTH_THRESHOLD) {
+			continue;
+		}
+
+		//check if elevation at max elevation is non-zero
+		if (max_elevation <= 0) {
+			fprintf(stderr, "Predicted max elevation is negative: %f\n", max_elevation);
+			return -1;
+		}
+
+		//check if max elevation predicted from the max elevation time is valid and the same
+		struct predict_observation max_ele_at_max_ele = predict_at_max_elevation(observer, orbital_elements, max_elevation_obs.time);
+		if (!((max_ele_at_max_ele.time > next_aos_time) && (max_ele_at_max_ele.time < next_los_time))) {
+			fprintf(stderr, "Max elevation predicted at max elevation time not within original pass: %f, %f, %f\n", max_ele_at_max_ele.time, next_aos_time, next_los_time);
+			return -1;
+		}
+		if (!fuzzyCompare(max_elevation_obs.time, max_ele_at_max_ele.time, EPSILON)) {
+			fprintf(stderr, "Max elevation time predicted from earlier max elevation time not the same: %f, %f\n", max_elevation_obs.time, max_ele_at_max_ele.time);
+			return -1;
+		}
+
+		//check if max elevation time predicted from selected time points throughout the pass is consistent
+		for (int i=0; i < NUM_TIME_STEPS-1; i++) {
+			double time = next_aos_time + i*(next_los_time - next_aos_time)/NUM_TIME_STEPS;
+			struct predict_observation new_max_elevation = predict_at_max_elevation(observer, orbital_elements, time);
+			if (!fuzzyCompare(new_max_elevation.time, max_elevation_obs.time, EPSILON)) {
+				fprintf(stderr, "Failed to predict consistent elevation times: Original time %f, new time %f, at timestep %d\n", max_elevation_obs.time, new_max_elevation.time, i);
+				return -1;
+			}
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Adds a function `predict_max_elevation(...)` for predicting the time for the maximum elevation of the next or the current pass. Solves issue #62.

This turned out to be more problematic than I thought, since satellites in deep space can have multiple maxima. However, assuming there can only be at most two, the function is accurate enough for most purposes (though dependent on predict_next_aos/los' ability to find a proper pass). Tests check the derivative, sample the pass for higher elevations and check the consistency of the found time when having different starting points throughout the pass. This is checked for various passes and various types of orbits. 

AOS/LOS functions were changed a bit for higher accuracy in problematic cases, and the tests were rewritten to check AOS/LOS in a more proper way for several passes. This should also be good preparation for increasing the numerical accuracy for #18.

Discussion questions: 

1.  The function returns the time for the max elevation, like `predict_next_aos/los` returns a time. Very consistent. But would it make more sense to return a `struct predict_observation`? In most cases, the user needs the additional properties, not only the time, and would have to call `predict_orbit` and `predict_observe_orbit` again after calling `predict_max_elevation`. `struct predict_observation` also has a time field.

2. In general, not sure about the name `predict_max_elevation`, since it doesn't return an elevation.