### PR TITLE
using cmake variables to make sure that pkgconfig mirrors lib/lib64

### DIFF
--- a/src/predict.pc.in
+++ b/src/predict.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/lib
-includedir=${prefix}/include
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: predict
 Description: A satellite orbit prediction library


### PR DESCRIPTION
Current libdir is hardcoded in pkg-config 'predict.pc.in' and breaks if cmake is placing the libs under lib64. This should fix the issue by using cmake env variables.