### PR TITLE
Rectify time span in max elevation tests

### DIFF
--- a/tests/maxelevation-t.cpp
+++ b/tests/maxelevation-t.cpp
@@ -157,7 +157,7 @@ int test_max_elevation(double start_time, predict_observer_t *observer, predict_
 	struct predict_observation obs;
 
 	for (int i=0; i < NUM_PASSES; i++) {
-		start_time += i*TIME_DIFF;
+		start_time += TIME_DIFF;
 
 		predict_orbit(orbital_elements, &orbit, start_time);
 		predict_observe_orbit(observer, &orbit, &obs);


### PR DESCRIPTION
Realized after commenting on https://github.com/la1k/libpredict/issues/97#issuecomment-354358747 that there was something extremely fishy with the time span of the max elevation tests. Turned out that I by mistake had tested passes at 1, 3, 6, 10, 15, ..., 210 days from the TLE epoch, instead of 1, 2, ..., 20 days from the epoch. Prediction time for MOLNIYA and SIRIUS-1 increases linearly with the time from TLE epoch (see issue comment), so this led to larger test times.

Old running times for the tests:

```
      Start 23: maxelevation-sat_ERS-1_201509261800
23/32 Test #23: maxelevation-sat_ERS-1_201509261800 ..........   Passed    0.30 sec
      Start 24: maxelevation-sat_GPS_BIIA-10_201509261800
24/32 Test #24: maxelevation-sat_GPS_BIIA-10_201509261800 ....   Passed    0.49 sec
      Start 25: maxelevation-sat_HINODE_201509261800
25/32 Test #25: maxelevation-sat_HINODE_201509261800 .........   Passed    0.28 sec
      Start 26: maxelevation-sat_ISS_201509261800
26/32 Test #26: maxelevation-sat_ISS_201509261800 ............   Passed    0.28 sec
      Start 27: maxelevation-sat_MOLNIYA_1-29_201509261800
27/32 Test #27: maxelevation-sat_MOLNIYA_1-29_201509261800 ...   Passed   14.50 sec
      Start 28: maxelevation-sat_SIRIUS-1_201509261800
28/32 Test #28: maxelevation-sat_SIRIUS-1_201509261800 .......   Passed    6.36 sec
      Start 29: maxelevation-sat_THOR_III_201509261800
29/32 Test #29: maxelevation-sat_THOR_III_201509261800 .......   Passed    0.00 sec
      Start 30: maxelevation-sat_VELA-1_201509261800
30/32 Test #30: maxelevation-sat_VELA-1_201509261800 .........   Passed    0.51 sec
```

New running times for the tests after correction:

```
      Start 23: maxelevation-sat_ERS-1_201509261800
23/32 Test #23: maxelevation-sat_ERS-1_201509261800 ..........   Passed    0.29 sec
      Start 24: maxelevation-sat_GPS_BIIA-10_201509261800
24/32 Test #24: maxelevation-sat_GPS_BIIA-10_201509261800 ....   Passed    0.49 sec
      Start 25: maxelevation-sat_HINODE_201509261800
25/32 Test #25: maxelevation-sat_HINODE_201509261800 .........   Passed    0.29 sec
      Start 26: maxelevation-sat_ISS_201509261800
26/32 Test #26: maxelevation-sat_ISS_201509261800 ............   Passed    0.30 sec
      Start 27: maxelevation-sat_MOLNIYA_1-29_201509261800
27/32 Test #27: maxelevation-sat_MOLNIYA_1-29_201509261800 ...   Passed    2.45 sec
      Start 28: maxelevation-sat_SIRIUS-1_201509261800
28/32 Test #28: maxelevation-sat_SIRIUS-1_201509261800 .......   Passed    1.87 sec
      Start 29: maxelevation-sat_THOR_III_201509261800
29/32 Test #29: maxelevation-sat_THOR_III_201509261800 .......   Passed    0.00 sec
      Start 30: maxelevation-sat_VELA-1_201509261800
30/32 Test #30: maxelevation-sat_VELA-1_201509261800 .........   Passed    0.53 sec
```

Due to the other factors mentioned in https://github.com/la1k/libpredict/issues/97#issuecomment-354358747, they still take 2.45 seconds at worst, but it is better than 14 seconds. :-)
