### PR TITLE
Define _XOPEN_SOURCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ cmake_policy(SET CMP0048 NEW)
 # patch = bump on any change
 # (tweak is not used by libpredict)
 project(libpredict VERSION 3.0.0 LANGUAGES C CXX)
+add_definitions(-D_XOPEN_SOURCE=700)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x") #for tests written in C++
 
 include(GNUInstallDirs)

--- a/src/julian_date.c
+++ b/src/julian_date.c
@@ -1,6 +1,8 @@
-#define _POSIX_C_SOURCE 1
 #include <predict/predict.h>
+
 #include <stdio.h>
+#include <time.h>
+
 #include "defs.h"
 
 /**

--- a/src/orbit.c
+++ b/src/orbit.c
@@ -1,6 +1,6 @@
-#define _XOPEN_SOURCE 600
 #include <math.h>
 #include <string.h>
+
 #include "defs.h"
 #include "unsorted.h"
 #include "sdp4.h"

--- a/src/sdp4.c
+++ b/src/sdp4.c
@@ -1,7 +1,8 @@
-#define _XOPEN_SOURCE 600
+#include "sdp4.h"
+
 #include <math.h>
 #include <stdbool.h>
-#include "sdp4.h"
+
 #include "defs.h"
 #include "unsorted.h"
 

--- a/src/unsorted.c
+++ b/src/unsorted.c
@@ -1,5 +1,5 @@
-#define _XOPEN_SOURCE 600
 #include "unsorted.h"
+
 #include "defs.h"
 
 void vec3_set(double v[3], double x, double y, double z)


### PR DESCRIPTION
Define _POSIX_C_SOURCE=1 at the top level to enable reentrant time
functions (especially gmtime_r) in time.h.

Closes #99.