### PR TITLE
Simplify Julian Date Computations

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -43,6 +43,8 @@
 #define SECONDS_PER_DAY	8.6400E4
 ///Difference between libpredict's predict_julian_date_t and the julian time format used in some of the internal functions
 #define JULIAN_TIME_DIFF 2444238.5
+///Unix timeststamp of 1979-12-31 00:00:00
+#define JULIAN_START_DAY 315446400
 ///@}
 
 /** \name Physical properties

--- a/src/julian_date.c
+++ b/src/julian_date.c
@@ -5,76 +5,14 @@
 
 #include "defs.h"
 
-/**
- * Create time_t in UTC from struct tm.
- *
- * \param timeinfo_utc Broken down time, assumed to be in UTC
- * \return Time in UTC
- **/
-time_t mktime_utc(const struct tm* timeinfo_utc)
-{
-	time_t curr_time = time(NULL);
-	int timezone_diff = 0; //deviation of the current timezone from UTC in seconds
-
-	//get UTC time, interpret resulting tm as a localtime
-	struct tm timeinfo_gmt;
-	gmtime_r(&curr_time, &timeinfo_gmt);
-	time_t time_gmt = mktime(&timeinfo_gmt);
-
-	//get localtime, interpret resulting tm as localtime
-	struct tm timeinfo_local;
-	localtime_r(&curr_time, &timeinfo_local);
-	time_t time_local = mktime(&timeinfo_local);
-
-	//find the time difference between the two interpretations
-	timezone_diff += difftime(time_local, time_gmt);
-
-	//hack for preventing mktime from assuming localtime: add timezone difference to the input struct.
-	struct tm ret_timeinfo;
-	ret_timeinfo.tm_sec = timeinfo_utc->tm_sec + timezone_diff;
-	ret_timeinfo.tm_min = timeinfo_utc->tm_min;
-	ret_timeinfo.tm_hour = timeinfo_utc->tm_hour;
-	ret_timeinfo.tm_mday = timeinfo_utc->tm_mday;
-	ret_timeinfo.tm_mon = timeinfo_utc->tm_mon;
-	ret_timeinfo.tm_year = timeinfo_utc->tm_year;
-	ret_timeinfo.tm_isdst = timeinfo_utc->tm_isdst;
-	return mktime(&ret_timeinfo);
-}
-
-/**
- * Helper function for getting the Julian day start date (1979-12-31 00:00 UTC) as time_t.
- *
- * \return Internally defined Julian start date (fixed)
- **/
-time_t get_julian_start_day()
-{
-	struct tm start_time;
-	start_time.tm_sec = 0;
-	start_time.tm_min = 0;
-	start_time.tm_hour = 0;
-	start_time.tm_mday = 31;
-	start_time.tm_mon = 11;
-	start_time.tm_year = 1979-1900;
-	start_time.tm_isdst = 0;
-	return mktime_utc(&start_time);
-}
-
 predict_julian_date_t predict_to_julian(time_t input_time)
 {
 	//get number of seconds since 1979-12-31 00:00:00 UTC, convert to days
-	double seconds = difftime(input_time, get_julian_start_day());
+	double seconds = difftime(input_time, JULIAN_START_DAY);
 	return seconds/SECONDS_PER_DAY;
 }
 
 time_t predict_from_julian(predict_julian_date_t date)
 {
-	double seconds_since = date*SECONDS_PER_DAY;
-	time_t ret_time = get_julian_start_day();
-	
-	//add number of seconds since julian start day to the julian start day, get current time_t
-	struct tm timeinfo;
-	gmtime_r(&ret_time, &timeinfo); 
-	timeinfo.tm_sec += seconds_since;
-	ret_time = mktime_utc(&timeinfo);
-	return ret_time;
+	return date * SECONDS_PER_DAY + JULIAN_START_DAY;
 }


### PR DESCRIPTION
This PR is an expansion on #79 - the Julian start time is constant, since everything is in UTC.

Additionally, as far as I can tell, there is no need to do any fancy time conversions in `predict_from_julian()`. We can effectively do the reverse of `predict_to_julian()`: multiply the Julian date by the seconds per day, then add JULIAN_START_DAY.

We are able to remove the `mktime_utc()` function after these changes, which I have found returns incorrect values in some edge cases. This works since since everything is in UTC, and removes the dependency on time functions or timezone handling.

Thanks for the consideration, and your work on this great library!